### PR TITLE
chore: add image urls for existing positions

### DIFF
--- a/src/apps/halofi/plugin.ts
+++ b/src/apps/halofi/plugin.ts
@@ -145,7 +145,8 @@ const plugin: AppPlugin = {
         displayProps: {
           title: game.gameNameShort,
           description: 'Challenge',
-          imageUrl: '', // TODO
+          imageUrl:
+            'https://raw.githubusercontent.com/valora-inc/dapp-list/main/assets/halofi.png',
         },
         balances: async () => {
           return [

--- a/src/apps/locked-celo/plugin.ts
+++ b/src/apps/locked-celo/plugin.ts
@@ -99,7 +99,8 @@ const plugin: AppPlugin = {
       displayProps: {
         title: 'Locked CELO',
         description: '', // TODO
-        imageUrl: '', // TODO
+        imageUrl:
+          'https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/CELO.png',
       },
       balances: async () => {
         return [

--- a/src/apps/ubeswap/plugin.ts
+++ b/src/apps/ubeswap/plugin.ts
@@ -69,7 +69,8 @@ async function getPoolPositionDefinition(
       return {
         title: `${token0.symbol} / ${token1.symbol}`,
         description: 'Pool',
-        imageUrl: '', // TODO
+        imageUrl:
+          'https://raw.githubusercontent.com/valora-inc/dapp-list/main/assets/ubeswap.png',
       }
     },
     pricePerShare: async ({ tokensByAddress }) => {


### PR DESCRIPTION
For now we'll use the dapp logo as the position image. This PR adds the images from our dapps list for halo-fi and ubeswap, and the Celo assets image for locked celo.

Fixes RET-734