### PR TITLE
fix(ubeswap): succeed when address has no blockchain interaction

### DIFF
--- a/src/apps/ubeswap/plugin.e2e.ts
+++ b/src/apps/ubeswap/plugin.e2e.ts
@@ -9,4 +9,12 @@ describe('getPositionDefinitions', () => {
     // Simple check to make sure we got some definitions
     expect(positions.length).toBeGreaterThan(0)
   })
+
+  it('should get no definitions for an address with no blockchain interaction', async () => {
+    const positions = await plugin.getPositionDefinitions(
+      'celo',
+      '0x0000000000000000000000000000000000007E57',
+    )
+    expect(positions.length).toBe(0)
+  })
 })

--- a/src/apps/ubeswap/plugin.ts
+++ b/src/apps/ubeswap/plugin.ts
@@ -119,7 +119,7 @@ async function getPoolPositionDefinitions(
     })
     .json<any>()
 
-  const pairs: Address[] = data.user.liquidityPositions
+  const pairs: Address[] = (data.user?.liquidityPositions ?? [])
     .filter((position: any) => Number(position.liquidityTokenBalance) > 0)
     .map((position: any) => position.pair.id)
 


### PR DESCRIPTION
This fixes a [crash](https://console.cloud.google.com/logs/query;cursorTimestamp=2023-06-01T23:38:49.095999956Z;query=resource.type%20%3D%20%22cloud_run_revision%22%0Aresource.labels.service_name%20%3D%20%22hooks-api%22%0Aresource.labels.location%20%3D%20%22us-central1%22%0Aseverity%3E%3DERROR%0Atimestamp%3D%222023-06-01T23:38:49.095999956Z%22%0AinsertId%3D%2264792c0900017c9ab7e0b59d%22;timeRange=P7D?project=celo-mobile-mainnet) when `data.user` is `null` when the address has no blockchain interaction.