### PR TITLE
feat: implement ubeswap claim reward shortcut + update cli tool to test

### DIFF
--- a/scripts/triggerShortcut.e2e.ts
+++ b/scripts/triggerShortcut.e2e.ts
@@ -3,7 +3,7 @@ import * as $ from 'shelljs'
 describe('triggerShortcut', () => {
   it('should trigger a shortcut successfully', () => {
     const result = $.exec(
-      'yarn triggerShortcut --network celo --address 0x2b8441ef13333ffa955c9ea5ab5b3692da95260d --app ubeswap --shortcut claim-reward --positionAddress 0x',
+      'yarn triggerShortcut --network celo --address 0x2b8441ef13333ffa955c9ea5ab5b3692da95260d --app ubeswap --shortcut claim-reward --positionAddress 0xda7f463c27ec862cfbf2369f3f74c364d050d93f',
     )
     expect(result.code).toBe(0)
   })

--- a/scripts/triggerShortcut.ts
+++ b/scripts/triggerShortcut.ts
@@ -1,7 +1,7 @@
 // Helper script to trigger a shortcut
 /* eslint-disable no-console */
 import yargs from 'yargs'
-import { Address, createWalletClient, http } from 'viem'
+import { Address, createWalletClient, http, createPublicClient } from 'viem'
 import { mnemonicToAccount } from 'viem/accounts'
 import { celo } from 'viem/chains'
 import { getShortcuts } from '../src/getShortcuts'
@@ -98,18 +98,26 @@ void (async () => {
     )
   }
 
-  const client = createWalletClient({
+  const wallet = createWalletClient({
     account,
+    chain: celo,
+    transport: http(),
+  })
+  const client = createPublicClient({
     chain: celo,
     transport: http(),
   })
 
   for (const transaction of result) {
-    const tx = await client.sendTransaction({
+    const txHash = await wallet.sendTransaction({
       // from: transaction.from as Address,
       to: transaction.to as Address,
       data: transaction.data as `0x${string}`,
     })
-    console.log('Transaction sent:', tx)
+    console.log(`Transaction sent, waiting for receipt: ${txHash}`)
+
+    const receipt = await client.waitForTransactionReceipt({ hash: txHash })
+
+    console.log('Transaction receipt:', receipt)
   }
 })()

--- a/src/shortcuts.ts
+++ b/src/shortcuts.ts
@@ -15,5 +15,9 @@ export interface ShortcutDefinition {
   ) => Promise<Transaction[]> // 0, 1 or more transactions to sign by the user
 }
 
-// TODO: define a transaction type
-type Transaction = any
+export type Transaction = {
+  network: string
+  from: string
+  to: string
+  data: string
+}


### PR DESCRIPTION
This implements the `onTrigger` method of the `claim-reward` shortcut for Ubeswap.

The `triggerShortcut` command line tool was updated to be able to send the resulting transaction.

Fixes RET-732

### Example

Here's our first successful shortcut call:

```
❯ yarn triggerShortcut --network celo --address 0x2b8441ef13333ffa955c9ea5ab5b3692da95260d --app ubeswap --shortcut claim-reward --positionAddress 0xda7f463c27ec862cfbf2369f3f74c364d050d93f --mnemonic "[XXX]"
yarn run v1.22.19
$ ts-node ./scripts/triggerShortcut.ts --network celo --address 0x2b8441ef13333ffa955c9ea5ab5b3692da95260d --app ubeswap --shortcut claim-reward --positionAddress 0xda7f463c27ec862cfbf2369f3f74c364d050d93f --mnemonic [XXX]
Triggering shortcut 'claim-reward' for app 'ubeswap' {
  network: 'celo',
  address: '0x2b8441ef13333ffa955c9ea5ab5b3692da95260d',
  positionAddress: '0xda7f463c27ec862cfbf2369f3f74c364d050d93f'
}
Transaction(s) to send: [
  {
    network: 'celo',
    from: '0x2b8441ef13333ffa955c9ea5ab5b3692da95260d',
    to: '0xda7f463c27ec862cfbf2369f3f74c364d050d93f',
    data: '0x3d18b912'
  }
]
Transaction sent, waiting for receipt: 0x3b3afc1e4b9f772dd8b94a05c3f09fb08c483d29df5c10907ab459c0edae7ec0
Transaction receipt: {
  blockHash: '0x062a5de76e2da70f7ef7d745b727403704758b97f2c094eb7e58d0cd16376685',
  blockNumber: 19956838n,
  contractAddress: null,
  cumulativeGasUsed: 1588217n,
  effectiveGasPrice: 6500000000n,
  from: '0x2b8441ef13333ffa955c9ea5ab5b3692da95260d',
  gasUsed: 71519n,
  logs: [
    {
      address: '0x00be915b9dcf56a3cbe739d9b9c202ca692409ec',
      topics: [Array],
      data: '0x00000000000000000000000000000000000000000000000000001900f03d2485',
      blockNumber: 19956838n,
      transactionHash: '0x3b3afc1e4b9f772dd8b94a05c3f09fb08c483d29df5c10907ab459c0edae7ec0',
      transactionIndex: 9,
      blockHash: '0x062a5de76e2da70f7ef7d745b727403704758b97f2c094eb7e58d0cd16376685',
      logIndex: 55,
      removed: false
    },
    {
      address: '0xda7f463c27ec862cfbf2369f3f74c364d050d93f',
      topics: [Array],
      data: '0x00000000000000000000000000000000000000000000000000001900f03d2485',
      blockNumber: 19956838n,
      transactionHash: '0x3b3afc1e4b9f772dd8b94a05c3f09fb08c483d29df5c10907ab459c0edae7ec0',
      transactionIndex: 9,
      blockHash: '0x062a5de76e2da70f7ef7d745b727403704758b97f2c094eb7e58d0cd16376685',
      logIndex: 56,
      removed: false
    }
  ],
  logsBloom: '0x00000000000000000000000000000000000200008000000000000000000000000000000000000000000000000000000000000000080000000000040000000000000000000400000000000008000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000010000000000000000100000000000000000800000000800000000000000080800000000000000020000000002000000000000000000000000000000000000400000000000000000002000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
  status: 'success',
  to: '0xda7f463c27ec862cfbf2369f3f74c364d050d93f',
  transactionHash: '0x3b3afc1e4b9f772dd8b94a05c3f09fb08c483d29df5c10907ab459c0edae7ec0',
  transactionIndex: 9,
  type: 'eip1559',
  feeCurrency: undefined,
  gatewayFee: null,
  gatewayFeeRecipient: undefined
}
✨  Done in 10.35s.
```