### PR TITLE
refactor!: rename plugin -> positions

### DIFF
--- a/docs/position-pricing-hooks.md
+++ b/docs/position-pricing-hooks.md
@@ -23,9 +23,9 @@ From the information provided by the hook, Valora can show the user the value of
 
 ### Structure
 
-Hooks are organized by application. For instance the Ubeswap hook is located in [`https://github.com/valora-inc/hooks/tree/main/src/apps/ubeswap`](https://github.com/valora-inc/hooks/tree/main/src/apps/ubeswap).
+Hooks are organized by application. For instance Ubeswap hooks are located in [`https://github.com/valora-inc/hooks/tree/main/src/apps/ubeswap`](https://github.com/valora-inc/hooks/tree/main/src/apps/ubeswap).
 
-They must implement the [`AppPlugin`](https://github.com/valora-inc/hooks/blob/main/src/plugin.ts) TypeScript interface.
+Position pricing hooks must implement the [`PositionsHook`](https://github.com/valora-inc/hooks/blob/main/src/positions.ts) TypeScript interface.
 
 ### Creating a Position Pricing Hook
 

--- a/scripts/getPositions.ts
+++ b/scripts/getPositions.ts
@@ -2,7 +2,7 @@
 /* eslint-disable no-console */
 import yargs from 'yargs'
 import BigNumber from 'bignumber.js'
-import { Token } from '../src/plugin'
+import { Token } from '../src/positions'
 import { getPositions } from '../src/getPositions'
 
 const argv = yargs(process.argv.slice(2))

--- a/src/apps/halofi/positions.e2e.ts
+++ b/src/apps/halofi/positions.e2e.ts
@@ -1,8 +1,8 @@
-import plugin from './plugin'
+import hook from './positions'
 
 describe('getPositionDefinitions', () => {
   it('should get the address definitions successfully', async () => {
-    const positions = await plugin.getPositionDefinitions(
+    const positions = await hook.getPositionDefinitions(
       'celo',
       '0x2b8441ef13333ffa955c9ea5ab5b3692da95260d',
     )

--- a/src/apps/halofi/positions.ts
+++ b/src/apps/halofi/positions.ts
@@ -1,10 +1,10 @@
 import BigNumber from 'bignumber.js'
 import { DecimalNumber } from '../../numbers'
 import {
-  AppPlugin,
+  PositionsHook,
   ContractPositionDefinition,
   TokenDefinition,
-} from '../../plugin'
+} from '../../positions'
 import got from 'got'
 
 // User-Agent header is required by the HaloFi API
@@ -100,7 +100,7 @@ type Reward = {
   type: string
 }
 
-const plugin: AppPlugin = {
+const hook: PositionsHook = {
   getInfo() {
     return {
       id: 'halofi',
@@ -165,4 +165,4 @@ const plugin: AppPlugin = {
   },
 }
 
-export default plugin
+export default hook

--- a/src/apps/locked-celo/positions.e2e.ts
+++ b/src/apps/locked-celo/positions.e2e.ts
@@ -1,8 +1,8 @@
-import plugin from './plugin'
+import hook from './positions'
 
 describe('getPositionDefinitions', () => {
   it('should get the address definitions successfully', async () => {
-    const positions = await plugin.getPositionDefinitions(
+    const positions = await hook.getPositionDefinitions(
       'celo',
       '0x2b8441ef13333ffa955c9ea5ab5b3692da95260d',
     )

--- a/src/apps/locked-celo/positions.test.ts
+++ b/src/apps/locked-celo/positions.test.ts
@@ -1,4 +1,4 @@
-import plugin from './plugin'
+import hook from './positions'
 
 jest.mock('viem', () => ({
   ...jest.requireActual('viem'),
@@ -15,7 +15,7 @@ describe('getPositionDefinitions', () => {
       12n * 10n ** 18n, // 12 locked celo
       [[], []], // pending withdrawals
     ])
-    const positions = await plugin.getPositionDefinitions(
+    const positions = await hook.getPositionDefinitions(
       'celo',
       '0x2b8441ef13333ffa955c9ea5ab5b3692da95260d',
     )
@@ -28,7 +28,7 @@ describe('getPositionDefinitions', () => {
       0n, // 0 locked celo
       [[], []], // pending withdrawals
     ])
-    const positions = await plugin.getPositionDefinitions(
+    const positions = await hook.getPositionDefinitions(
       'celo',
       '0x2b8441ef13333ffa955c9ea5ab5b3692da95260d',
     )

--- a/src/apps/locked-celo/positions.ts
+++ b/src/apps/locked-celo/positions.ts
@@ -1,4 +1,4 @@
-import { AppPlugin, ContractPositionDefinition } from '../../plugin'
+import { PositionsHook, ContractPositionDefinition } from '../../positions'
 import {
   Address,
   ContractFunctionExecutionError,
@@ -33,7 +33,7 @@ function zip<A, B>(as: readonly A[], bs: readonly B[]) {
   return res
 }
 
-const plugin: AppPlugin = {
+const hook: PositionsHook = {
   getInfo() {
     return {
       id: 'locked-celo',
@@ -121,4 +121,4 @@ const plugin: AppPlugin = {
   },
 }
 
-export default plugin
+export default hook

--- a/src/apps/moola/positions.e2e.ts
+++ b/src/apps/moola/positions.e2e.ts
@@ -1,8 +1,8 @@
-import plugin from './plugin'
+import hook from './positions'
 
 describe('getPositionDefinitions', () => {
   it('should get the address definitions successfully', async () => {
-    const positions = await plugin.getPositionDefinitions(
+    const positions = await hook.getPositionDefinitions(
       'celo',
       '0x2b8441ef13333ffa955c9ea5ab5b3692da95260d',
     )

--- a/src/apps/moola/positions.test.ts
+++ b/src/apps/moola/positions.test.ts
@@ -1,4 +1,4 @@
-import plugin from './plugin'
+import hook from './positions'
 
 jest.mock('viem', () => ({
   ...jest.requireActual('viem'),
@@ -24,7 +24,7 @@ describe('getPositionDefinitions', () => {
       0n, // 0 cREAL stable debt
       2n * 10n ** 18n, // 2 CELO stable debt
     ])
-    const positions = await plugin.getPositionDefinitions(
+    const positions = await hook.getPositionDefinitions(
       mockNetwork,
       mockAddress,
     )
@@ -57,7 +57,7 @@ describe('getPositionDefinitions', () => {
       0n, // 0 cREAL stable debt
       0n, // 0 CELO stable debt
     ])
-    const positions = await plugin.getPositionDefinitions(
+    const positions = await hook.getPositionDefinitions(
       mockNetwork,
       mockAddress,
     )

--- a/src/apps/moola/positions.ts
+++ b/src/apps/moola/positions.ts
@@ -1,4 +1,4 @@
-import { AppPlugin, AppTokenPositionDefinition } from '../../plugin'
+import { PositionsHook, AppTokenPositionDefinition } from '../../positions'
 import { Address, createPublicClient, http } from 'viem'
 import { celo } from 'viem/chains'
 import { erc20Abi } from '../../abis/erc-20'
@@ -29,7 +29,7 @@ function getAppTokenPositionDefinition(
   }
 }
 
-const plugin: AppPlugin = {
+const hook: PositionsHook = {
   getInfo() {
     return {
       id: 'moola',
@@ -59,4 +59,4 @@ const plugin: AppPlugin = {
   },
 }
 
-export default plugin
+export default hook

--- a/src/apps/ubeswap/positions.e2e.ts
+++ b/src/apps/ubeswap/positions.e2e.ts
@@ -1,8 +1,8 @@
-import plugin from './plugin'
+import hook from './positions'
 
 describe('getPositionDefinitions', () => {
   it('should get the address definitions successfully', async () => {
-    const positions = await plugin.getPositionDefinitions(
+    const positions = await hook.getPositionDefinitions(
       'celo',
       '0x2b8441ef13333ffa955c9ea5ab5b3692da95260d',
     )
@@ -11,7 +11,7 @@ describe('getPositionDefinitions', () => {
   })
 
   it('should get no definitions for an address with no blockchain interaction', async () => {
-    const positions = await plugin.getPositionDefinitions(
+    const positions = await hook.getPositionDefinitions(
       'celo',
       '0x0000000000000000000000000000000000007E57',
     )

--- a/src/apps/ubeswap/positions.ts
+++ b/src/apps/ubeswap/positions.ts
@@ -1,11 +1,11 @@
 import {
-  AppPlugin,
+  PositionsHook,
   AppTokenPosition,
   AppTokenPositionDefinition,
   ContractPositionDefinition,
   PositionDefinition,
   TokenDefinition,
-} from '../../plugin'
+} from '../../positions'
 import got from 'got'
 import BigNumber from 'bignumber.js'
 import { uniswapV2PairAbi } from './abis/uniswap-v2-pair'
@@ -253,7 +253,7 @@ async function getFarmPositionDefinitions(
   return positions
 }
 
-const plugin: AppPlugin = {
+const hook: PositionsHook = {
   getInfo() {
     return {
       id: 'ubeswap',
@@ -275,4 +275,4 @@ const plugin: AppPlugin = {
   },
 }
 
-export default plugin
+export default hook

--- a/src/positions.ts
+++ b/src/positions.ts
@@ -1,7 +1,7 @@
 import { DecimalNumber, SerializedDecimalNumber } from './numbers'
 
 // Plugin interface that authors will implement
-export interface AppPlugin {
+export interface PositionsHook {
   getInfo(): AppInfo
   // Get position definitions for a given address
   getPositionDefinitions(


### PR DESCRIPTION
This moves positions plugins to the new "hooks" terminology.
Following the addition of shortcuts.