### PR TITLE
chore: reduce excessive logs

### DIFF
--- a/docs/position-pricing-hooks.md
+++ b/docs/position-pricing-hooks.md
@@ -126,3 +126,9 @@ Example for locked-celo:
 ```sh
 yarn getPositions --network celo --address 0x2b8441ef13333ffa955c9ea5ab5b3692da95260d --apps locked-celo
 ```
+
+You can get additional logs about how positions are resolved by the runtime by setting the `LOG_LEVEL` environment variable to `debug`.
+
+```sh
+LOG_LEVEL=debug yarn getPositions --network celo --address 0x2b8441ef13333ffa955c9ea5ab5b3692da95260d --apps locked-celo
+```

--- a/src/apps/ubeswap/positions.ts
+++ b/src/apps/ubeswap/positions.ts
@@ -123,8 +123,6 @@ async function getPoolPositionDefinitions(
     .filter((position: any) => Number(position.liquidityTokenBalance) > 0)
     .map((position: any) => position.pair.id)
 
-  // console.log({ pairs })
-
   // Get all positions
   const positions = await Promise.all(
     pairs.map(async (pair) => {
@@ -182,8 +180,6 @@ async function getFarmPositionDefinitions(
       rewardsEarned: data[4 * i + 3] as bigint,
     }))
     .filter((farm) => farm.balance > 0)
-
-  // console.log({ userFarms })
 
   const positions = await Promise.all(
     userFarms.map(async (farm) => {

--- a/src/runtime/getPositions.ts
+++ b/src/runtime/getPositions.ts
@@ -1,5 +1,3 @@
-// Allow console logs for now, since we're early in development
-/* eslint-disable no-console */
 import got from 'got'
 import BigNumber from 'bignumber.js'
 import {
@@ -322,7 +320,7 @@ export async function getPositions(
       ),
     ),
   ).then((definitions) => definitions.flat())
-  console.log('positions definitions', JSON.stringify(definitions, null, ' '))
+  logger.debug({ definitions }, 'positions definitions')
 
   // Get the base tokens info
   const baseTokensInfo = await getBaseTokensInfo()
@@ -341,7 +339,7 @@ export async function getPositions(
     })
 
     if (definitionsToResolve.length === 0) {
-      console.log('No more positions to resolve')
+      logger.debug('No more positions to resolve')
       break
     }
 
@@ -350,10 +348,7 @@ export async function getPositions(
       position.tokens.map((token) => addSourceAppId(token, position.appId)),
     )
 
-    console.log(
-      'allTokenDefinitions',
-      JSON.stringify(allTokenDefinitions, null, ' '),
-    )
+    logger.debug({ allTokenDefinitions }, 'allTokenDefinitions')
 
     // Get the tokens definitions for which we don't have the base token info or position definition
     const unresolvedTokenDefinitions = allTokenDefinitions.filter(
@@ -363,10 +358,7 @@ export async function getPositions(
         ] && !visitedDefinitions[tokenDefinition.address],
     )
 
-    console.log(
-      'unresolvedTokenDefinitions',
-      JSON.stringify(unresolvedTokenDefinitions, null, ' '),
-    )
+    logger.debug({ unresolvedTokenDefinitions }, 'unresolvedTokenDefinitions')
 
     // Get the token info for the unresolved token definitions
     const newUnlistedBaseTokensInfo: TokensInfo = {}
@@ -398,14 +390,8 @@ export async function getPositions(
       )
     ).filter((p): p is Exclude<typeof p, null | undefined> => p != null)
 
-    console.log(
-      'appTokenDefinitions',
-      JSON.stringify(appTokenDefinitions, null, ' '),
-    )
-    console.log(
-      'newUnlistedBaseTokensInfo',
-      JSON.stringify(newUnlistedBaseTokensInfo, null, ' '),
-    )
+    logger.debug({ appTokenDefinitions }, 'appTokenDefinitions')
+    logger.debug({ newUnlistedBaseTokensInfo }, 'newUnlistedBaseTokensInfo')
 
     unlistedBaseTokensInfo = {
       ...unlistedBaseTokensInfo,
@@ -416,7 +402,7 @@ export async function getPositions(
     definitionsToResolve = appTokenDefinitions
   }
 
-  console.log({
+  logger.debug({
     unlistedBaseTokensInfo,
     visitedPositions: visitedDefinitions,
   })
@@ -479,7 +465,7 @@ export async function getPositions(
 
     const type = positionDefinition.type
 
-    console.log('Resolving definition', type, positionDefinition.address)
+    logger.debug('Resolving definition', type, positionDefinition.address)
 
     const appInfo = hooksByAppId[positionDefinition.appId].getInfo()
 


### PR DESCRIPTION
Moved the noisy `console.log` in the runtime to `logger.debug`