### PR TITLE
fix(ubeswap): missing image since it was removed from dapp-list

### DIFF
--- a/src/apps/ubeswap/positions.ts
+++ b/src/apps/ubeswap/positions.ts
@@ -70,7 +70,7 @@ async function getPoolPositionDefinition(
         title: `${token0.symbol} / ${token1.symbol}`,
         description: 'Pool',
         imageUrl:
-          'https://raw.githubusercontent.com/valora-inc/dapp-list/main/assets/ubeswap.png',
+          'https://raw.githubusercontent.com/valora-inc/dapp-list/ab12ab234b4a6e01eff599c6bd0b7d5b44d6f39d/assets/ubeswap.png',
       }
     },
     pricePerShare: async ({ tokensByAddress }) => {


### PR DESCRIPTION
Following the delisting of Ubeswap in https://github.com/valora-inc/dapp-list/pull/510
The related positions image was broken.

**before/after**

<img src="https://github.com/valora-inc/hooks/assets/57791/764b4ae7-3e11-4bc8-a10a-f7efc6459dcf" width="50%" /><img src="https://github.com/valora-inc/hooks/assets/57791/30d0aecf-629e-4f82-ba57-622ef7800c37" width="50%" />
