### PR TITLE
feat!: make `getAppTokenDefinition` optional

### DIFF
--- a/src/apps/gooddollar/positions.ts
+++ b/src/apps/gooddollar/positions.ts
@@ -109,10 +109,6 @@ const hook: PositionsHook = {
 
     return [position]
   },
-  getAppTokenDefinition() {
-    // We don't need this for now, since there are no intermediary tokens
-    throw new Error('Not implemented')
-  },
 }
 
 export default hook

--- a/src/apps/halofi/positions.ts
+++ b/src/apps/halofi/positions.ts
@@ -70,10 +70,6 @@ const hook: PositionsHook = {
       return position
     })
   },
-  getAppTokenDefinition(_context: TokenDefinition) {
-    // We don't need this for now, since there are no intermediary tokens
-    throw new Error('Not implemented')
-  },
 }
 
 export default hook

--- a/src/apps/locked-celo/positions.ts
+++ b/src/apps/locked-celo/positions.ts
@@ -118,10 +118,6 @@ const hook: PositionsHook = {
 
     return [position]
   },
-  getAppTokenDefinition() {
-    // We don't need this for now, since there are no intermediary tokens
-    throw new Error('Not implemented')
-  },
 }
 
 export default hook

--- a/src/apps/moola/positions.ts
+++ b/src/apps/moola/positions.ts
@@ -56,10 +56,6 @@ const hook: PositionsHook = {
         getAppTokenPositionDefinition(debtTokenDefinition, network),
     )
   },
-  getAppTokenDefinition(_) {
-    // We don't need this for now, since there are no intermediary tokens
-    throw new Error('Not implemented')
-  },
 }
 
 export default hook

--- a/src/runtime/getPositions.ts
+++ b/src/runtime/getPositions.ts
@@ -370,6 +370,11 @@ export async function getPositions(
             // TODO: We'll probably need to allow hooks to specify the app id themselves
             const { sourceAppId } = tokenDefinition
             const hook = hooksByAppId[sourceAppId]
+            if (!hook.getAppTokenDefinition) {
+              throw new Error(
+                `Positions hook for app '${sourceAppId}' does not implement 'getAppTokenDefinition'. Please implement it to resolve the intermediary app token definition for ${tokenDefinition.address} (${tokenDefinition.network}).`,
+              )
+            }
             const appTokenDefinition = await hook
               .getAppTokenDefinition(tokenDefinition)
               .then((definition) => addAppId(definition, sourceAppId))

--- a/src/types/positions.ts
+++ b/src/types/positions.ts
@@ -9,7 +9,10 @@ export interface PositionsHook {
     address: string,
   ): Promise<PositionDefinition[]>
   // Get an app token definition from a token definition
-  getAppTokenDefinition(
+  // This is needed when a position definition has one ore more intermediary app tokens, which are not base tokens.
+  // For instance a farm position composed of a LP token.
+  // The runtime needs to call this function to resolve such intermediary tokens.
+  getAppTokenDefinition?(
     tokenDefinition: TokenDefinition,
   ): Promise<AppTokenPositionDefinition>
 }


### PR DESCRIPTION
`getAppTokenDefinition` is only needed in 2 situations:
1. when the token definition returns intermediary tokens which are not base tokens
2. when a hook depends on another hook's tokens which are not base tokens

Though 2 is not yet fully supported as we haven't had the case yet, but it exists. For instance Revo tokens depending on Ubeswap LP tokens.

So far only Ubeswap and Curve really needed to implement it.
This change aims to make the common use case simpler to implement for hooks author.

The runtime will through an useful error instead when `getAppTokenDefinition` is needed but no implemented.