### PR TITLE
fix(uniswap): hide positions with no liquidity

### DIFF
--- a/src/apps/uniswap/positions.ts
+++ b/src/apps/uniswap/positions.ts
@@ -43,6 +43,7 @@ const hook: PositionsHook = {
         token0: pool.token0.toLowerCase(),
         token1: pool.token1.toLowerCase(),
       }))
+      .filter((pool) => pool.liquidity > 0)
       .map((pool) => {
         return {
           type: 'contract-position-definition',


### PR DESCRIPTION
Once the liquidity is withdrawn, we shouldn't display a position.

See Slack [thread](https://valora-app.slack.com/archives/C04B61SJ6DS/p1695662883555879).
The thread is about something else, but I noticed this other bug in the screenshot.