### PR TITLE
fix: explicit return type for getClient

### DIFF
--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -1,4 +1,4 @@
-import { Chain, createPublicClient, http } from 'viem'
+import { Chain, createPublicClient, http, PublicClient } from 'viem'
 import {
   arbitrum,
   arbitrumSepolia,
@@ -23,7 +23,9 @@ const networkIdToViemChain: Record<NetworkId, Chain> = {
   [NetworkId['op-sepolia']]: optimismSepolia,
 }
 
-export function getClient(networkId: NetworkId) {
+export function getClient(
+  networkId: NetworkId,
+): PublicClient<ReturnType<typeof http>, Chain> {
   const rpcUrl = getConfig().NETWORK_ID_TO_RPC_URL[networkId]
   return createPublicClient({
     chain: networkIdToViemChain[networkId],


### PR DESCRIPTION
strangely, the build fails while deploying, but not locally, without this return type. see [here](https://console.cloud.google.com/cloud-build/builds;region=us-central1/08bd8607-3f69-4b7d-aae6-69116fa6e414;step=2?project=celo-mobile-alfajores)

tested by deploying to staging

cc https://linear.app/valora/issue/RET-941/%5Bhooks%5D-multichain-support which I am doing on a contract basis