### PR TITLE
refactor(multichain)!: accept multiple network ids for get positions and get shortcuts

### DIFF
--- a/src/api/index.test.ts
+++ b/src/api/index.test.ts
@@ -22,7 +22,7 @@ import './index' // NOTE: there are side effects of importing this module-- load
 jest.mock('../runtime/getPositions')
 jest.mock('../runtime/getShortcuts')
 
-const TEST_POSITIONS: Position[] = [
+const TEST_POSITIONS_CELO: Position[] = [
   {
     type: 'app-token',
     appId: 'ubeswap',
@@ -71,7 +71,64 @@ const TEST_POSITIONS: Position[] = [
   },
 ]
 
-jest.mocked(getPositions).mockResolvedValue(TEST_POSITIONS)
+const TEST_POSITIONS_ETHEREUM: Position[] = [
+  {
+    type: 'app-token',
+    appId: 'uniswap',
+    appName: 'Uniswap',
+    networkId: NetworkId['ethereum-mainnet'],
+    address: '0x31f9dee850b4284b81b52b25a3194f2fc8ff18cf',
+    symbol: 'ULP',
+    decimals: 18,
+    label: 'Pool: UNI / USDC',
+    displayProps: {
+      title: 'UNI / USDC',
+      description: 'Pool',
+      imageUrl: '',
+    },
+    tokenId: 'ethereum-mainnet:0x31f9dee850b4284b81b52b25a3194f2fc8ff18cf',
+    tokens: [
+      {
+        type: 'base-token',
+        networkId: NetworkId['celo-mainnet'],
+        address: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
+        symbol: 'UNI',
+        decimals: 18,
+        priceUsd: '11.17' as SerializedDecimalNumber,
+        balance: '12445.060074286696111325' as SerializedDecimalNumber,
+        tokenId: 'ethereum-mainnet:0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
+      },
+      {
+        type: 'base-token',
+        networkId: NetworkId['celo-mainnet'],
+        address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+        symbol: 'USDC',
+        decimals: 18,
+        priceUsd: '1' as SerializedDecimalNumber,
+        balance: '2.061316226302041758' as SerializedDecimalNumber,
+        tokenId: 'ethereum-mainnet:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      },
+    ],
+    pricePerShare: [
+      '1.77845724145984437582' as SerializedDecimalNumber,
+      '2.0128827016512212377' as SerializedDecimalNumber,
+    ],
+    priceUsd: '0.25' as SerializedDecimalNumber,
+    balance: '100.01' as SerializedDecimalNumber,
+    supply: '170.10' as SerializedDecimalNumber,
+    availableShortcutIds: [],
+  },
+]
+
+jest.mocked(getPositions).mockImplementation(async (networkId) => {
+  if (networkId === NetworkId['celo-mainnet']) {
+    return TEST_POSITIONS_CELO
+  } else if (networkId === NetworkId['ethereum-mainnet']) {
+    return TEST_POSITIONS_ETHEREUM
+  } else {
+    return []
+  }
+})
 
 const TEST_SHORTCUTS: Awaited<ReturnType<typeof getShortcuts>> = [
   {
@@ -100,16 +157,31 @@ jest.mocked(getShortcuts).mockResolvedValue(TEST_SHORTCUTS)
 const WALLET_ADDRESS = '0x0000000000000000000000000000000000007E57'
 
 describe('GET /getPositions', () => {
-  it('returns balances', async () => {
+  it('returns balances for celo', async () => {
     const server = getTestServer('hooks-api')
     await request(server)
       .get('/getPositions')
       .query({
-        networkId: 'celo-mainnet',
+        networkIds: [NetworkId['celo-mainnet']],
         address: WALLET_ADDRESS,
       })
       .expect(200)
-      .expect({ message: 'OK', data: TEST_POSITIONS })
+      .expect({ message: 'OK', data: TEST_POSITIONS_CELO })
+  })
+
+  it('returns balances for celo and ethereum', async () => {
+    const server = getTestServer('hooks-api')
+    await request(server)
+      .get('/getPositions')
+      .query({
+        networkIds: [NetworkId['celo-mainnet'], NetworkId['ethereum-mainnet']],
+        address: WALLET_ADDRESS,
+      })
+      .expect(200)
+      .expect({
+        message: 'OK',
+        data: TEST_POSITIONS_CELO.concat(TEST_POSITIONS_ETHEREUM),
+      })
   })
 
   it('returns 400 when address is missing', async () => {
@@ -117,7 +189,7 @@ describe('GET /getPositions', () => {
     const response = await request(server)
       .get('/getPositions')
       .query({
-        networkId: 'celo-mainnet',
+        network: 'celo', // note: this old schema should still be supported. only the address should be reported as an error.
       })
       .expect(400)
     expect(response.body).toMatchInlineSnapshot(`
@@ -162,7 +234,7 @@ describe('POST /triggerShortcut', () => {
         address: WALLET_ADDRESS,
         appId: TEST_SHORTCUTS[0].appId,
         shortcutId: TEST_SHORTCUTS[0].id,
-        positionAddress: TEST_POSITIONS[0].address,
+        positionAddress: TEST_POSITIONS_CELO[0].address,
       })
       .expect(200)
     expect(response.body).toEqual({
@@ -172,7 +244,7 @@ describe('POST /triggerShortcut', () => {
           {
             networkId: 'celo-mainnet',
             from: WALLET_ADDRESS.toLowerCase(),
-            to: TEST_POSITIONS[0].address,
+            to: TEST_POSITIONS_CELO[0].address,
             data: '0xTEST',
           },
         ],
@@ -189,7 +261,7 @@ describe('POST /triggerShortcut', () => {
         address: WALLET_ADDRESS,
         appId: TEST_SHORTCUTS[0].appId,
         shortcutId: 'flarf',
-        positionAddress: TEST_POSITIONS[0].address,
+        positionAddress: TEST_POSITIONS_CELO[0].address,
       })
       .expect(400)
     expect(response.body).toMatchInlineSnapshot(`

--- a/src/api/index.test.ts
+++ b/src/api/index.test.ts
@@ -189,7 +189,7 @@ describe('GET /getPositions', () => {
     const response = await request(server)
       .get('/getPositions')
       .query({
-        network: 'celo', // note: this old schema should still be supported. only the address should be reported as an error.
+        network: 'celo', // note: this old schema should still be supported. only the missing address should be reported as an error.
       })
       .expect(400)
     expect(response.body).toMatchInlineSnapshot(`

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -21,7 +21,9 @@ function asyncHandler(handler: HttpFunction) {
   return valoraAsyncHandler(handler, logger)
 }
 
-function getNetworkIds(args: {network: LegacyNetwork} | {networkIds: NetworkId | NetworkId[]}): NetworkId[] {
+function getNetworkIds(
+  args: { network: LegacyNetwork } | { networkIds: NetworkId | NetworkId[] },
+): NetworkId[] {
   if ('network' in args) {
     return [legacyNetworkToNetworkId[args.network]]
   } else if (Array.isArray(args.networkIds)) {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -21,10 +21,15 @@ function asyncHandler(handler: HttpFunction) {
   return valoraAsyncHandler(handler, logger)
 }
 
-const backwardsCompatibleNetworkSchema = z.union([
-  z.object({ network: z.nativeEnum(LegacyNetwork) }), // legacy schema: 'celo' or 'celoAlfajores' passed as 'network' field on the request
-  z.object({ networkId: z.nativeEnum(NetworkId) }), // current schema: any member of NetworkId enum passed as 'networkId' field on the request
-])
+function getNetworkIds(args: {network: LegacyNetwork} | {networkIds: NetworkId | NetworkId[]}): NetworkId[] {
+  if ('network' in args) {
+    return [legacyNetworkToNetworkId[args.network]]
+  } else if (Array.isArray(args.networkIds)) {
+    return args.networkIds
+  } else {
+    return [args.networkIds]
+  }
+}
 
 function createApp() {
   const config = getConfig()
@@ -45,7 +50,15 @@ function createApp() {
           .regex(/^0x[a-fA-F0-9]{40}$/)
           .transform((val) => val.toLowerCase()),
       }),
-      backwardsCompatibleNetworkSchema,
+      z.union([
+        z.object({ network: z.nativeEnum(LegacyNetwork) }), // legacy schema: 'celo' or 'celoAlfajores' passed as 'network' field on the request
+        z.object({
+          networkIds: z
+            .array(z.nativeEnum(NetworkId))
+            .nonempty()
+            .or(z.nativeEnum(NetworkId)), // singleton arrays sometimes serialize as single values
+        }), // current schema: any members of NetworkId enum passed as 'networkIds' field on the request
+      ]),
     ),
   })
 
@@ -54,16 +67,19 @@ function createApp() {
     asyncHandler(async (req, res) => {
       const parsedRequest = await parseRequest(req, getHooksRequestSchema)
       const { address } = parsedRequest.query
-      const networkId =
-        'network' in parsedRequest.query
-          ? legacyNetworkToNetworkId[parsedRequest.query.network]
-          : parsedRequest.query.networkId
-      const positions = await getPositions(
-        networkId,
-        address,
-        config.POSITION_IDS,
-        config.GET_TOKENS_INFO_URL,
-      )
+      const networkIds = getNetworkIds(parsedRequest.query)
+      const positions = (
+        await Promise.all(
+          networkIds.map((networkId) =>
+            getPositions(
+              networkId,
+              address,
+              config.POSITION_IDS,
+              config.GET_TOKENS_INFO_URL,
+            ),
+          ),
+        )
+      ).flat()
       res.send({ message: 'OK', data: positions })
     }),
   )
@@ -85,15 +101,14 @@ function createApp() {
     asyncHandler(async (req, res) => {
       const parsedRequest = await parseRequest(req, getHooksRequestSchema)
       const { address } = parsedRequest.query
-      const networkId =
-        'network' in parsedRequest.query
-          ? legacyNetworkToNetworkId[parsedRequest.query.network]
-          : parsedRequest.query.networkId
-      const shortcuts = await getShortcuts(
-        networkId,
-        address,
-        config.SHORTCUT_IDS,
-      )
+      const networkIds = getNetworkIds(parsedRequest.query)
+      const shortcuts = (
+        await Promise.all(
+          networkIds.map((networkId) =>
+            getShortcuts(networkId, address, config.SHORTCUT_IDS),
+          ),
+        )
+      ).flat()
       res.send({ message: 'OK', data: shortcuts })
     }),
   )
@@ -112,7 +127,10 @@ function createApp() {
           .regex(/^0x[a-fA-F0-9]{40}$/)
           .transform((val) => val.toLowerCase()),
       }),
-      backwardsCompatibleNetworkSchema,
+      z.union([
+        z.object({ network: z.nativeEnum(LegacyNetwork) }), // legacy schema: 'celo' or 'celoAlfajores' passed as 'network' field on the request
+        z.object({ networkId: z.nativeEnum(NetworkId) }), // current schema: any member of NetworkId enum passed as 'networkId' field on the request
+      ]),
     ),
   })
 


### PR DESCRIPTION
BREAKING CHANGE: instead of singular "networkId", takes array "networkIds" as query parameter for endpoints to get positions and shortcuts. The "networkId" query param was added recently (by me) and not used by any wallet versions, so this should be ok.

In my last hooks PR, I assumed we would want to keep the api more or less intact, just substituting "networkId" for "network" since it expected different values. However, when I went to implement the wallet changes, I noticed that we'd need to make a separate request to the hooks endpoints for every network we want to support, which doesn't scale well. Taking multiple network ID's as a query parameter seems like the better approach. 

tested manually with local wallet build, verified that Celo and Eth positions can be displayed together. 

![Simulator Screen Shot - iPhone 13 - 2024-04-04 at 10 59 18](https://github.com/valora-inc/hooks/assets/7979215/992f0a36-a569-4778-82f1-28a29d72840a)
