### PR TITLE
feat: add fallbackPriceUsd as escape hatch

### DIFF
--- a/src/runtime/getPositions.test.ts
+++ b/src/runtime/getPositions.test.ts
@@ -185,7 +185,7 @@ describe(getPositions, () => {
                 fallbackPriceUsd: toSerializedDecimalNumber(0.5),
               },
             ],
-            // Meaning that 1 share of the vault is worth 2 underlying token
+            // Meaning that 1 share of the vault is worth 2 underlying tokens
             pricePerShare: [toDecimalNumber(2n, 0)],
             displayProps: {
               title: 'Beefy crvUSD/​WBTC/​WETH Vault',

--- a/src/runtime/getPositions.test.ts
+++ b/src/runtime/getPositions.test.ts
@@ -1,11 +1,13 @@
 import { getPositions } from './getPositions'
 import * as hooks from './getHooks'
 import {
+  AppTokenPosition,
   AppTokenPositionDefinition,
   ContractPositionDefinition,
   PositionsHook,
+  UnknownAppTokenError,
 } from '../types/positions'
-import { toDecimalNumber } from '../types/numbers'
+import { SerializedDecimalNumber, toDecimalNumber } from '../types/numbers'
 import { logger } from '../log'
 import { NetworkId } from '../types/networkId'
 import got from 'got'
@@ -135,7 +137,7 @@ describe(getPositions, () => {
 
     mockMulticall.mockResolvedValue([
       'ULP', // Symbol for 0xda7f463c27ec862cfbf2369f3f74c364d050d93f
-      18n, // Decimals
+      18, // Decimals
     ])
     getHooksSpy.mockResolvedValue({
       'test-hook': testHook,
@@ -150,5 +152,91 @@ describe(getPositions, () => {
     ).rejects.toThrow(
       "Positions hook for app 'test-hook' does not implement 'getAppTokenDefinition'. Please implement it to resolve the intermediary app token definition for 0x1e593f1fe7b61c53874b54ec0c59fd0d5eb8621e (celo-mainnet)",
     )
+  })
+
+  it("should use the fallbackPriceUsd if the token can't be found", async () => {
+    const testHook: PositionsHook = {
+      getInfo() {
+        return {
+          id: 'beefy-price-escape',
+          name: 'Beefy Price Escape',
+          description: 'Beefy with price escape hatch for underlying tokens',
+        }
+      },
+
+      async getPositionDefinitions(networkId: NetworkId, _address: string) {
+        if (networkId !== NetworkId['op-mainnet']) {
+          return []
+        }
+
+        return [
+          {
+            type: 'app-token-definition',
+            networkId,
+            // Beefy crvUSD/​WBTC/​WETH Vault
+            // https://app.beefy.com/vault/curve-op-tricrypto-crvusd
+            address: '0xf82160Bad52C235102174aE5E7f36d5099DEEad3',
+            tokens: [
+              {
+                // Underlying Curve LP token
+                address: '0x4456d13Fc6736e8e8330394c0C622103E06ea419',
+                networkId,
+                // Fallback until we can properly decompose the token into base tokens
+                fallbackPriceUsd: '0.5' as SerializedDecimalNumber,
+              },
+            ],
+            // Meaning that 1 share of the vault is worth 2 underlying token
+            pricePerShare: [toDecimalNumber(2n, 0)],
+            displayProps: {
+              title: 'Beefy crvUSD/​WBTC/​WETH Vault',
+              description: 'Vault',
+              imageUrl: '',
+            },
+          },
+        ]
+      },
+
+      async getAppTokenDefinition(tokenDefinition) {
+        throw new UnknownAppTokenError(tokenDefinition)
+      },
+    }
+
+    mockMulticall
+      .mockResolvedValueOnce([
+        '3c-crvUSD', // Symbol for 0x4456d13Fc6736e8e8330394c0C622103E06ea419
+        18, // Decimals
+      ])
+      .mockResolvedValueOnce([
+        'mooCurveTriCrypto-crvUSD', // Symbol for 0xf82160Bad52C235102174aE5E7f36d5099DEEad3
+        18, // Decimals
+      ])
+      .mockResolvedValueOnce([
+        30n * 10n ** 18n, // balanceOf 0xf82160Bad52C235102174aE5E7f36d5099DEEad3
+        1000n * 10n ** 18n, // totalSupply
+      ])
+    getHooksSpy.mockResolvedValue({
+      'beefy-price-escape': testHook,
+    })
+    getSpy.mockReturnValue({
+      json: jest.fn().mockResolvedValue(mockTokensInfo),
+    } as any)
+    const positions = await getPositions(
+      NetworkId['op-mainnet'],
+      '0x0000000000000000000000000000000000007e57',
+      [],
+      'mock-token-info-url',
+    )
+    expect(positions.length).toBe(1)
+    const beefyPosition = positions[0] as AppTokenPosition
+    expect(beefyPosition.appId).toBe('beefy-price-escape')
+    expect(beefyPosition.tokens.length).toBe(1)
+    expect(beefyPosition.tokens[0].tokenId).toBe(
+      'op-mainnet:0x4456d13fc6736e8e8330394c0c622103e06ea419',
+    )
+    expect(beefyPosition.tokens[0].balance).toBe('60')
+    expect(beefyPosition.tokens[0].priceUsd).toBe('0.5') // Fallback price, since the token can't be found
+    expect(beefyPosition.balance).toBe('30')
+    expect(beefyPosition.priceUsd).toBe('1')
+    expect(beefyPosition.supply).toBe('1000')
   })
 })

--- a/src/runtime/getPositions.test.ts
+++ b/src/runtime/getPositions.test.ts
@@ -173,7 +173,7 @@ describe(getPositions, () => {
           {
             type: 'app-token-definition',
             networkId,
-            // Beefy crvUSD/​WBTC/​WETH Vault
+            // Beefy crvUSD/WBTC/WETH Vault
             // https://app.beefy.com/vault/curve-op-tricrypto-crvusd
             address: '0xf82160Bad52C235102174aE5E7f36d5099DEEad3',
             tokens: [

--- a/src/runtime/getPositions.test.ts
+++ b/src/runtime/getPositions.test.ts
@@ -7,7 +7,7 @@ import {
   PositionsHook,
   UnknownAppTokenError,
 } from '../types/positions'
-import { SerializedDecimalNumber, toDecimalNumber } from '../types/numbers'
+import { toDecimalNumber, toSerializedDecimalNumber } from '../types/numbers'
 import { logger } from '../log'
 import { NetworkId } from '../types/networkId'
 import got from 'got'
@@ -182,7 +182,7 @@ describe(getPositions, () => {
                 address: '0x4456d13Fc6736e8e8330394c0C622103E06ea419',
                 networkId,
                 // Fallback until we can properly decompose the token into base tokens
-                fallbackPriceUsd: '0.5' as SerializedDecimalNumber,
+                fallbackPriceUsd: toSerializedDecimalNumber(0.5),
               },
             ],
             // Meaning that 1 share of the vault is worth 2 underlying token

--- a/src/runtime/getPositions.ts
+++ b/src/runtime/getPositions.ts
@@ -460,7 +460,14 @@ export async function getPositions(
                 tokenDefinition.address as Address,
                 networkId,
               )
-              newUnlistedBaseTokensInfo[erc20TokenInfo.tokenId] = erc20TokenInfo
+              newUnlistedBaseTokensInfo[erc20TokenInfo.tokenId] = {
+                ...erc20TokenInfo,
+                // TODO: remove the need for this fallback
+                // and implement the apps to resolve the tokens
+                ...(tokenDefinition.fallbackPriceUsd && {
+                  priceUsd: tokenDefinition.fallbackPriceUsd,
+                }),
+              }
               return
             }
             throw e

--- a/src/types/positions.ts
+++ b/src/types/positions.ts
@@ -23,6 +23,14 @@ export interface PositionsHook {
 export interface TokenDefinition {
   address: string
   networkId: NetworkId
+  // Escape hatch for priceUsd in case the token is not in our list of base tokens
+  // and it's difficult to decompose the token into base token
+  // Ideally we should add apps to resolve such tokens
+  // For example: Beefy vault depends on Aave, Curve, etc.
+  // but we don't yet have all these apps implemented
+  // Note: there's also a limitation in the runtime as it can't yet always resolve tokens between apps
+  // This will be added "soon"
+  fallbackPriceUsd?: SerializedDecimalNumber
 }
 
 // To be returned when `getAppTokenDefinition` can't resolve a token

--- a/src/types/positions.ts
+++ b/src/types/positions.ts
@@ -29,7 +29,7 @@ export interface TokenDefinition {
   // For example: Beefy vault depends on Aave, Curve, etc.
   // but we don't yet have all these apps implemented
   // Note: there's also a limitation in the runtime as it can't yet always resolve tokens between apps
-  // This will be added "soon"
+  // This will be fixed "soon"
   fallbackPriceUsd?: SerializedDecimalNumber
 }
 


### PR DESCRIPTION
Related to https://github.com/valora-inc/hooks/pull/396 and discussed with @gnardini ([thread](https://valora-app.slack.com/archives/C04NFRMSZQX/p1718275117206789))

This should make it easier to implement Beefy which relies on a wide variety of underlying tokens for which we don't yet have apps that could decompose them.