### PR TITLE
feat: allow getting positions without a user address

### DIFF
--- a/scripts/getPositions.ts
+++ b/scripts/getPositions.ts
@@ -17,9 +17,9 @@ const argv = yargs(process.argv.slice(2))
     },
     address: {
       alias: 'a',
-      describe: 'Address to get positions for',
+      describe:
+        'Optional address to get positions for. When not specified it lists all available positions.',
       type: 'string',
-      demandOption: true,
     },
     apps: {
       alias: 'p',

--- a/src/apps/curve/positions.ts
+++ b/src/apps/curve/positions.ts
@@ -189,7 +189,10 @@ const hook: PositionsHook = {
       description: 'Curve pools',
     }
   },
-  getPositionDefinitions(networkId, address) {
+  async getPositionDefinitions(networkId, address) {
+    if (!address) {
+      return []
+    }
     return getPoolPositionDefinitions(networkId, address as Address)
   },
   async getAppTokenDefinition({ networkId, address }: TokenDefinition) {

--- a/src/apps/gooddollar/positions.ts
+++ b/src/apps/gooddollar/positions.ts
@@ -35,7 +35,7 @@ const hook: PositionsHook = {
     }
   },
   async getPositionDefinitions(networkId, address) {
-    if (networkId !== NetworkId['celo-mainnet']) {
+    if (networkId !== NetworkId['celo-mainnet'] || !address) {
       // hook implementation currently hardcoded to Celo mainnet (contract addresses in particular)
       return []
     }

--- a/src/apps/halofi/positions.ts
+++ b/src/apps/halofi/positions.ts
@@ -20,7 +20,7 @@ const hook: PositionsHook = {
     }
   },
   async getPositionDefinitions(networkId, address) {
-    if (networkId !== NetworkId['celo-mainnet']) {
+    if (networkId !== NetworkId['celo-mainnet'] || !address) {
       // dapp is only on Celo, and implementation is hardcoded to Celo mainnet (contract addresses in particular)
       return []
     }

--- a/src/apps/hedgey/positions.ts
+++ b/src/apps/hedgey/positions.ts
@@ -21,7 +21,7 @@ const hook: PositionsHook = {
   },
 
   async getPositionDefinitions(networkId: NetworkId, address: string) {
-    if (networkId !== NetworkId['celo-mainnet']) {
+    if (networkId !== NetworkId['celo-mainnet'] || !address) {
       // hook implementation currently hardcoded to Celo mainnet (nft addresses in particular)
       return []
     }

--- a/src/apps/locked-celo/positions.ts
+++ b/src/apps/locked-celo/positions.ts
@@ -46,7 +46,7 @@ const hook: PositionsHook = {
     }
   },
   async getPositionDefinitions(networkId, address) {
-    if (networkId !== NetworkId['celo-mainnet']) {
+    if (networkId !== NetworkId['celo-mainnet'] || !address) {
       // dapp is only on Celo and hook implementation is hardcoded to Celo mainnet (contract addresses in particular)
       return []
     }

--- a/src/apps/mento/positions.ts
+++ b/src/apps/mento/positions.ts
@@ -180,6 +180,10 @@ const hook: PositionsHook = {
     }
   },
   async getPositionDefinitions(networkId, address) {
+    if (!address) {
+      return []
+    }
+
     const positions = await Promise.all([
       getAirdropPositionDefinition(networkId, address as Address),
       getVeMentoPositionDefinition(networkId, address as Address),

--- a/src/apps/moola/positions.ts
+++ b/src/apps/moola/positions.ts
@@ -42,7 +42,7 @@ const hook: PositionsHook = {
     }
   },
   async getPositionDefinitions(networkId, address) {
-    if (networkId !== NetworkId['celo-mainnet']) {
+    if (networkId !== NetworkId['celo-mainnet'] || !address) {
       // dapp is only on Celo, and implementation is hardcoded to Celo mainnet (contract addresses in particular)
       return []
     }

--- a/src/apps/ubeswap/positions.ts
+++ b/src/apps/ubeswap/positions.ts
@@ -301,7 +301,7 @@ const hook: PositionsHook = {
     }
   },
   async getPositionDefinitions(networkId, address) {
-    if (networkId !== NetworkId['celo-mainnet']) {
+    if (networkId !== NetworkId['celo-mainnet'] || !address) {
       // dapp is only on Celo, and implementation is hardcoded to Celo mainnet (contract addresses in particular)
       return []
     }

--- a/src/apps/uniswap/positions.ts
+++ b/src/apps/uniswap/positions.ts
@@ -24,7 +24,7 @@ const hook: PositionsHook = {
     }
   },
   async getPositionDefinitions(networkId, address) {
-    if (networkId !== NetworkId['celo-mainnet']) {
+    if (networkId !== NetworkId['celo-mainnet'] || !address) {
       // hook implementation currently hardcoded to Celo mainnet (contract addresses in particular)
       return []
     }

--- a/src/types/positions.ts
+++ b/src/types/positions.ts
@@ -5,10 +5,12 @@ import { NetworkId } from './networkId'
 export interface PositionsHook {
   getInfo(): AppInfo
 
-  // Get position definitions for a given address
+  // Get position definitions
+  // Note: it can be called with or without an address
+  // If called without an address, it should return all positions available for the network
   getPositionDefinitions(
     networkId: NetworkId,
-    address: string,
+    address?: string,
   ): Promise<PositionDefinition[]>
 
   // Get an app token definition from a token definition


### PR DESCRIPTION
First step to be able to able to list possible positions for an app without needing a user address.

The idea is we'll tag some positions for the "earn" feature and the wallet will query for them.

One thing though is for some dapps (uniswap, curve), there could be hundreds of pools, which can make getting the data for them quite expensive in terms of number of RPC calls needed (even with multicall).
We can start by listing the most popular ones and also add caching.

This PR doesn't yet do that and simply returns `[]` (empty list of positions) when a user address isn't provided.
We'll add support for each app incrementally.

I have another PR, showing an example of this for Curve.

Also: this should eventually allow us to remove the optional `getAppTokenDefinition`.
If we're able to list all available positions for an app, `getAppTokenDefinition` becomes unnecessary.

Fixes RET-1086