### PR TITLE
feat(shortcuts): author defined trigger inputs

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -36,7 +36,7 @@ function getNetworkIds(
 function serializeShortcuts(
   shortcuts: Awaited<ReturnType<typeof getShortcuts>>,
 ) {
-  // TODO: consider using JSON schema for triggerInputShape
+  // TODO: consider returning JSON schema for triggerInputShape
   return shortcuts.map(({ onTrigger, triggerInputShape, ...shortcut }) => ({
     ...shortcut,
   }))

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -33,6 +33,15 @@ function getNetworkIds(
   }
 }
 
+function serializeShortcuts(
+  shortcuts: Awaited<ReturnType<typeof getShortcuts>>,
+) {
+  // TODO: consider using JSON schema for triggerInputShape
+  return shortcuts.map(({ onTrigger, triggerInputShape, ...shortcut }) => ({
+    ...shortcut,
+  }))
+}
+
 function createApp() {
   const config = getConfig()
 
@@ -96,7 +105,7 @@ function createApp() {
         undefined,
         config.SHORTCUT_IDS,
       )
-      res.send({ message: 'OK', data: shortcuts })
+      res.send({ message: 'OK', data: serializeShortcuts(shortcuts) })
     }),
   )
 
@@ -113,7 +122,7 @@ function createApp() {
           ),
         )
       ).flat()
-      res.send({ message: 'OK', data: shortcuts })
+      res.send({ message: 'OK', data: serializeShortcuts(shortcuts) })
     }),
   )
 
@@ -126,10 +135,6 @@ function createApp() {
           .transform((val) => val.toLowerCase()),
         appId: z.string({ required_error: 'appId is required' }),
         shortcutId: z.string({ required_error: 'shortcutId is required' }),
-        positionAddress: z
-          .string({ required_error: 'positionAddress is required' })
-          .regex(/^0x[a-fA-F0-9]{40}$/)
-          .transform((val) => val.toLowerCase()),
       }),
       z.union([
         z.object({ network: z.nativeEnum(LegacyNetwork) }), // legacy schema: 'celo' or 'celoAlfajores' passed as 'network' field on the request
@@ -146,7 +151,7 @@ function createApp() {
         triggerShortcutRequestSchema,
       )
 
-      const { address, appId, shortcutId, positionAddress } = parsedRequest.body
+      const { address, appId, shortcutId } = parsedRequest.body
 
       const networkId =
         'network' in parsedRequest.body
@@ -165,11 +170,19 @@ function createApp() {
         )
       }
 
-      const transactions = await shortcut.onTrigger(
+      // Now check the trigger input
+      const parsedTriggerInput = await parseRequest(
+        req,
+        z.object({
+          body: z.object(shortcut.triggerInputShape),
+        }),
+      )
+
+      const transactions = await shortcut.onTrigger({
         networkId,
         address,
-        positionAddress,
-      )
+        ...parsedTriggerInput.body,
+      })
       res.send({ message: 'OK', data: { transactions } })
     }),
   )

--- a/src/apps/gooddollar/shortcuts.ts
+++ b/src/apps/gooddollar/shortcuts.ts
@@ -1,8 +1,9 @@
 import { Address, createPublicClient, http, encodeFunctionData } from 'viem'
 import { celo } from 'viem/chains'
-import { ShortcutsHook } from '../../types/shortcuts'
+import { createShortcut, ShortcutsHook } from '../../types/shortcuts'
 import { ubiSchemeAbi } from './abis/ubi-scheme'
 import { NetworkId } from '../../types/networkId'
+import { ZodAddressLowerCased } from '../../types/address'
 
 const client = createPublicClient({
   chain: celo,
@@ -16,16 +17,19 @@ const hook: ShortcutsHook = {
     }
 
     return [
-      {
+      createShortcut({
         id: 'claim-reward',
         name: 'Claim',
         description: 'Claim daily UBI rewards',
         networkIds: [NetworkId['celo-mainnet']],
         category: 'claim',
-        async onTrigger(networkId, address, positionAddress) {
+        triggerInputShape: {
+          positionAddress: ZodAddressLowerCased,
+        },
+        async onTrigger({ networkId, address, positionAddress }) {
           // This isn't strictly needed, but will help while we're developing shortcuts
           const { request } = await client.simulateContract({
-            address: positionAddress as Address, // This is the ubi contract address
+            address: positionAddress, // This is the ubi contract address
             abi: ubiSchemeAbi,
             functionName: 'claim',
             account: address as Address,
@@ -46,7 +50,7 @@ const hook: ShortcutsHook = {
             },
           ]
         },
-      },
+      }),
     ]
   },
 }

--- a/src/apps/hedgey/shortcuts.e2e.ts
+++ b/src/apps/hedgey/shortcuts.e2e.ts
@@ -20,11 +20,11 @@ describe('getShortcutDefinitions', () => {
       )
       const shortcut = shortcuts[0]
 
-      const transactions = await shortcut.onTrigger(
-        NetworkId['celo-mainnet'],
-        '0x2b8441ef13333ffa955c9ea5ab5b3692da95260d',
-        POSITION_ADDRESS,
-      )
+      const transactions = await shortcut.onTrigger({
+        networkId: NetworkId['celo-mainnet'],
+        address: '0x2b8441ef13333ffa955c9ea5ab5b3692da95260d',
+        positionAddress: POSITION_ADDRESS,
+      })
 
       expect(transactions.length).toEqual(1)
     })

--- a/src/apps/ubeswap/shortcuts.ts
+++ b/src/apps/ubeswap/shortcuts.ts
@@ -1,8 +1,9 @@
 import { Address, createPublicClient, http, encodeFunctionData } from 'viem'
 import { celo } from 'viem/chains'
-import { ShortcutsHook } from '../../types/shortcuts'
+import { createShortcut, ShortcutsHook } from '../../types/shortcuts'
 import { stakingRewardsAbi } from './abis/staking-rewards'
 import { NetworkId } from '../../types/networkId'
+import { ZodAddressLowerCased } from '../../types/address'
 
 const client = createPublicClient({
   chain: celo,
@@ -16,13 +17,16 @@ const hook: ShortcutsHook = {
     }
 
     return [
-      {
+      createShortcut({
         id: 'claim-reward',
         name: 'Claim',
         description: 'Claim rewards for staked liquidity',
         networkIds: [NetworkId['celo-mainnet']],
         category: 'claim',
-        async onTrigger(networkId, address, positionAddress) {
+        triggerInputShape: {
+          positionAddress: ZodAddressLowerCased,
+        },
+        async onTrigger({ networkId, address, positionAddress }) {
           // This isn't strictly needed, but will help while we're developing shortcuts
           const { request } = await client.simulateContract({
             address: positionAddress as Address, // This is the farm address
@@ -46,7 +50,7 @@ const hook: ShortcutsHook = {
             },
           ]
         },
-      },
+      }),
     ]
   },
 }

--- a/src/types/address.ts
+++ b/src/types/address.ts
@@ -1,0 +1,8 @@
+import { Address as ZodAddress } from 'abitype/zod'
+import { Address } from 'viem'
+
+export type { Address } from 'viem'
+
+export const ZodAddressLowerCased = ZodAddress.transform((val) => {
+  return val.toLowerCase() as Address
+})

--- a/src/types/shortcuts.ts
+++ b/src/types/shortcuts.ts
@@ -1,22 +1,25 @@
+import { z, ZodObject, ZodRawShape } from 'zod'
 import { NetworkId } from './networkId'
 
 export interface ShortcutsHook {
   getShortcutDefinitions(
     networkId: NetworkId,
     address?: string,
-  ): Promise<ShortcutDefinition[]>
+  ): Promise<ShortcutDefinition<any>[]>
 }
 
-export interface ShortcutDefinition {
+export interface ShortcutDefinition<TriggerInputShape extends ZodRawShape> {
   id: string // Example: claim-reward
   name: string // Example: Claim
   description: string // Example: Claim your reward
   networkIds: NetworkId[] // Example: ['celo-mainnet']
   category?: 'claim' // We'll add more categories later
+  triggerInputShape: TriggerInputShape // Zod object shape of the input for the trigger
   onTrigger: (
-    networkId: NetworkId,
-    address: string,
-    positionAddress: string,
+    args: {
+      networkId: NetworkId
+      address: string
+    } & z.infer<ZodObject<TriggerInputShape>>,
   ) => Promise<Transaction[]> // 0, 1 or more transactions to sign by the user
 }
 
@@ -25,4 +28,12 @@ export type Transaction = {
   from: string
   to: string
   data: string
+}
+
+// This is to help TS infer the type of the triggerInputShape
+// so the onTrigger args can be properly typed
+export function createShortcut<TriggerInputShape extends ZodRawShape>(
+  definition: ShortcutDefinition<TriggerInputShape>,
+) {
+  return definition
 }


### PR DESCRIPTION
Up until now shortcuts were limited to the following input arguments:
- `networkId`
- `address`
- `positionAddress`

This PR allows arbitrary inputs when triggering shortcuts.
`networkId` and `address` are still always required, but any other argument is now up to the shortcut author.
`positionAddress` is now also entirely author defined.

This allows triggering shortcuts with a token and token amount for instance for the "earn" feature of Valora.
And allows for much richer interactions with apps.

Fixes RET-1086
