### PR TITLE
fix(compound): use extra id

### DIFF
--- a/src/apps/compound/positions.ts
+++ b/src/apps/compound/positions.ts
@@ -119,7 +119,8 @@ const hook: PositionsHook = {
           positions.push({
             type: 'contract-position-definition',
             networkId,
-            address: `${market.toLowerCase()}-${token.toLowerCase()}-${type}`,
+            address: market.toLowerCase(),
+            extraId: `${token.toLowerCase()}-${type.toLowerCase()}`,
             tokens: [
               {
                 address: token.toLowerCase(),


### PR DESCRIPTION
Now that we can specify `extraId`, use it instead of the address hack.