### PR TITLE
wip: getEarnPositions

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -107,6 +107,46 @@ function createApp() {
     }),
   )
 
+  // Positions for the Earn feature
+  // For now limited to specific positions
+  app.get(
+    '/getEarnPositions',
+    asyncHandler(async (req, res) => {
+      const parsedRequest = await parseRequest(req, getHooksRequestSchema)
+      const networkIds = getNetworkIds(parsedRequest.query).filter(
+        (network) =>
+          // For now limit to Arbitrum
+          network === NetworkId['arbitrum-one'] ||
+          network === NetworkId['arbitrum-sepolia'],
+      )
+
+      const positions = (
+        await Promise.all(
+          networkIds.map((networkId) =>
+            getPositions(
+              networkId,
+              undefined,
+              // For now limit to Aave
+              ['aave'],
+              config.GET_TOKENS_INFO_URL,
+            ),
+          ),
+        )
+      )
+        .flat()
+        .filter(
+          // For now limit to specific positions
+          (position) =>
+            position.positionId ===
+              `${NetworkId['arbitrum-one']}:0x724dc807b04555b71ed48a6896b6f41593b8c637` ||
+            position.positionId ===
+              `${NetworkId['arbitrum-sepolia']}:0x460b97bd498e1157530aeb3086301d5225b91216`,
+        )
+
+      res.send({ message: 'OK', data: positions })
+    }),
+  )
+
   // Deprecated route, will be removed in the future
   app.get(
     '/getShortcuts',

--- a/src/apps/aave/positions.ts
+++ b/src/apps/aave/positions.ts
@@ -10,6 +10,7 @@ import BigNumber from 'bignumber.js'
 import { NetworkId } from '../../types/networkId'
 import { getClient } from '../../runtime/client'
 import { uiPoolDataProviderV3Abi } from './abis/ui-pool-data-provider-v3'
+import { getTokenId } from '../../runtime/getTokenId'
 
 // See https://github.com/bgd-labs/aave-address-book/tree/fbb590953db44d62a756d4639cb77ea58afb299c/src/ts
 // and https://docs.aave.com/developers/deployed-contracts/v3-mainnet
@@ -121,7 +122,9 @@ const hook: PositionsHook = {
             type: 'app-token-definition',
             networkId,
             address: reserveData.aTokenAddress.toLowerCase(),
-            tokens: [{ address: reserveData.underlyingAsset, networkId }],
+            tokens: [
+              { address: reserveData.underlyingAsset.toLowerCase(), networkId },
+            ],
             availableShortcutIds: ['deposit', 'withdraw'],
             displayProps: {
               title: reserveData.symbol,
@@ -130,6 +133,14 @@ const hook: PositionsHook = {
             },
             dataProps: {
               apy: supplyApy,
+              depositTokenId: getTokenId({
+                networkId,
+                address: reserveData.underlyingAsset.toLowerCase(),
+              }),
+              withdrawTokenId: getTokenId({
+                networkId,
+                address: reserveData.aTokenAddress.toLowerCase(),
+              }),
             },
             pricePerShare: [new BigNumber(1) as DecimalNumber],
           } satisfies AppTokenPositionDefinition),

--- a/src/types/positions.ts
+++ b/src/types/positions.ts
@@ -64,6 +64,8 @@ export type DataProps = EarnDataProps
 
 export interface EarnDataProps {
   apy: number
+  depositTokenId: string
+  withdrawTokenId: string
   // We'll add more fields here as needed
 }
 


### PR DESCRIPTION
First simple draft proposal for the new endpoint to retrieve earn pools.

For now I've kept the `Position` shape. I thought initially I'd change the shape more, but then I realized we may not need to change it. With the exception of `displayProps` content maybe.

It contains the necessary data to replace the static data from [pools.ts](https://github.com/valora-inc/troopo/blob/324a1d2108a4b25141227656b09b00c37f4a5482/src/earnV2/pools.ts).
Except I haven't added `tvl` yet and `reward` (that one could/should probably be done via the claimable token category we already support).

Plus also the info about the deposit and withdraw token IDs to use to trigger the shortcut actions.

Let me know what you think.

```
❯ curl --silent "http://localhost:18000/getEarnPositions?networkIds=arbitrum-sepolia" | jq
{
  "message": "OK",
  "data": [
    {
      "type": "app-token",
      "networkId": "arbitrum-sepolia",
      "address": "0x460b97bd498e1157530aeb3086301d5225b91216",
      "tokenId": "arbitrum-sepolia:0x460b97bd498e1157530aeb3086301d5225b91216",
      "positionId": "arbitrum-sepolia:0x460b97bd498e1157530aeb3086301d5225b91216",
      "appId": "aave",
      "appName": "Aave",
      "symbol": "aArbSepUSDC",
      "decimals": 6,
      "label": "USDC",
      "displayProps": {
        "title": "USDC",
        "description": "Supplied (APY: 4.43%)",
        "imageUrl": "https://raw.githubusercontent.com/valora-inc/dapp-list/main/assets/aave.png"
      },
      "dataProps": {
        "apy": 4.426825317210925,
        "depositTokenId": "arbitrum-sepolia:0x75faf114eafb1bdbe2f0316df893fd58ce46aa4d",
        "withdrawTokenId": "arbitrum-sepolia:0x460b97bd498e1157530aeb3086301d5225b91216"
      },
      "tokens": [
        {
          "tokenId": "arbitrum-sepolia:0x75faf114eafb1bdbe2f0316df893fd58ce46aa4d",
          "networkId": "arbitrum-sepolia",
          "address": "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d",
          "symbol": "USDC",
          "decimals": 6,
          "priceUsd": "0",
          "imageUrl": "",
          "type": "base-token",
          "balance": "0"
        }
      ],
      "pricePerShare": [
        "1"
      ],
      "priceUsd": "0",
      "balance": "0",
      "supply": "112236.136077",
      "availableShortcutIds": [
        "deposit",
        "withdraw"
      ]
    }
  ]
}
```

Note: `priceUsd` is 0 because it's on Sepolia.

Fixes RET-1112