### PR TITLE
refactor: unified config access and simplifications for better devx

### DIFF
--- a/scripts/getPositions.ts
+++ b/scripts/getPositions.ts
@@ -31,12 +31,6 @@ const argv = yargs(process.argv.slice(2))
         return array.flatMap((v) => v.split(','))
       },
     },
-    getTokensInfoUrl: {
-      alias: 'g',
-      describe: 'URL to get token info from',
-      type: 'string',
-      default: 'https://api.mainnet.valora.xyz/getTokensInfo',
-    },
   })
   .parseSync()
 
@@ -55,12 +49,7 @@ function breakdownToken(token: Token): string {
 }
 
 void (async () => {
-  const positions = await getPositions(
-    argv.networkId,
-    argv.address,
-    argv.apps,
-    argv.getTokensInfoUrl,
-  )
+  const positions = await getPositions(argv.networkId, argv.address, argv.apps)
   console.log('positions', JSON.stringify(positions, null, ' '))
 
   console.table(

--- a/src/api/index.test.ts
+++ b/src/api/index.test.ts
@@ -8,9 +8,9 @@ import { getShortcuts } from '../runtime/getShortcuts'
 import { Position } from '../types/positions'
 import { SerializedDecimalNumber } from '../types/numbers'
 import { NetworkId } from '../types/networkId'
-import { getConfig } from './config'
+import { getConfig } from '../config'
 
-jest.mock('./config')
+jest.mock('../config')
 jest.mocked(getConfig).mockReturnValue({
   POSITION_IDS: [],
   GET_TOKENS_INFO_URL: 'https://valoraapp.com/mock-endpoint',

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -6,7 +6,7 @@ import {
 } from '@valora/http-handler'
 import express from 'express'
 import { z } from 'zod'
-import { getConfig } from './config'
+import { getConfig } from '../config'
 import { logger } from '../log'
 import { parseRequest } from './parseRequest'
 import { getPositions } from '../runtime/getPositions'
@@ -94,12 +94,7 @@ function createApp() {
       const positions = (
         await Promise.all(
           networkIds.map((networkId) =>
-            getPositions(
-              networkId,
-              address,
-              config.POSITION_IDS,
-              config.GET_TOKENS_INFO_URL,
-            ),
+            getPositions(networkId, address, config.POSITION_IDS),
           ),
         )
       ).flat()

--- a/src/apps/beefy/positions.e2e.ts
+++ b/src/apps/beefy/positions.e2e.ts
@@ -1,17 +1,13 @@
 import hook from './positions'
 import { NetworkId } from '../../types/networkId'
-import { getConfig } from '../../api/config'
 import { getPositions } from '../../runtime/getPositions'
 
 describe('getPositionDefinitions', () => {
   it('should get the address definitions successfully', async () => {
-    const config = getConfig()
-
     const positions = await getPositions(
       NetworkId['op-mainnet'],
       '0x2b8441ef13333ffa955c9ea5ab5b3692da95260d',
       ['beefy'],
-      config.GET_TOKENS_INFO_URL,
     )
 
     expect(

--- a/src/apps/compound/positions.e2e.ts
+++ b/src/apps/compound/positions.e2e.ts
@@ -1,17 +1,13 @@
-import { getConfig } from '../../api/config'
 import { getPositions } from '../../runtime/getPositions'
 import { NetworkId } from '../../types/networkId'
 import hook from './positions'
 
 describe('getPositionDefinitions', () => {
   it('should get the address definitions successfully for supply & collateral', async () => {
-    const config = getConfig()
-
     const positions = await getPositions(
       NetworkId['op-mainnet'],
       '0x2b8441ef13333ffa955c9ea5ab5b3692da95260d',
       ['compound'],
-      config.GET_TOKENS_INFO_URL,
     )
 
     const supplyPosition = positions.find((p) =>
@@ -26,13 +22,10 @@ describe('getPositionDefinitions', () => {
   })
 
   it('should get the address definitions successfully for debt & collateral', async () => {
-    const config = getConfig()
-
     const positions = await getPositions(
       NetworkId['arbitrum-one'],
       '0x2b8441ef13333ffa955c9ea5ab5b3692da95260d',
       ['compound'],
-      config.GET_TOKENS_INFO_URL,
     )
 
     const collateralPosition = positions.find((p) =>

--- a/src/apps/ubeswap/positions.e2e.ts
+++ b/src/apps/ubeswap/positions.e2e.ts
@@ -1,17 +1,13 @@
-import { getConfig } from '../../api/config'
 import { getPositions } from '../../runtime/getPositions'
 import { NetworkId } from '../../types/networkId'
 import hook from './positions'
 
 describe('getPositionDefinitions', () => {
   it('should get the address definitions successfully', async () => {
-    const config = getConfig()
-
     const positions = await getPositions(
       NetworkId['celo-mainnet'],
       '0x2b8441ef13333ffa955c9ea5ab5b3692da95260d',
       ['ubeswap'],
-      config.GET_TOKENS_INFO_URL,
     )
 
     // Uniswap v2 farm definitions

--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -1,4 +1,4 @@
-import { networkIdToRpcUrlTransform } from './config'
+import { networkIdToRpcUrlTransform } from '.'
 
 describe('config', () => {
   describe('networkIdToRpcUrlTransform', () => {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -41,29 +41,30 @@ export function getConfig(): Config {
       .transform(networkIdToRpcUrlTransform),
   })
 
-  const productionSchema = z.intersection(
-    sharedSchema,
-    z.object({
-      GOOGLE_CLOUD_PROJECT: z.string().min(1),
-      POSITION_IDS: z.string().transform((val) => val.split(',')),
-      SHORTCUT_IDS: z.string().transform((val) => val.split(',')),
-    }),
-  )
+  const productionSchema = sharedSchema.extend({
+    GOOGLE_CLOUD_PROJECT: z.string().min(1),
+    POSITION_IDS: z.string().transform((val) => val.split(',')),
+    SHORTCUT_IDS: z.string().transform((val) => val.split(',')),
+  })
 
-  const developmentSchema = z.intersection(
-    sharedSchema,
-    z.object({
-      GOOGLE_CLOUD_PROJECT: z.string().default('dev-project'),
-      POSITION_IDS: z
-        .string()
-        .default('')
-        .transform((val) => (val === '' ? [] : val.split(','))),
-      SHORTCUT_IDS: z
-        .string()
-        .default('')
-        .transform((val) => (val === '' ? [] : val.split(','))),
-    }),
-  )
+  // Provide defaults in development
+  // TODO: consider providing a default .env.development file instead
+  const developmentSchema = sharedSchema.extend({
+    GET_TOKENS_INFO_URL: z
+      .string()
+      .default(
+        'https://blockchain-api-dot-celo-mobile-mainnet.appspot.com/tokensInfo',
+      ),
+    GOOGLE_CLOUD_PROJECT: z.string().default('dev-project'),
+    POSITION_IDS: z
+      .string()
+      .default('')
+      .transform((val) => (val === '' ? [] : val.split(','))),
+    SHORTCUT_IDS: z
+      .string()
+      .default('')
+      .transform((val) => (val === '' ? [] : val.split(','))),
+  })
 
   return process.env.NODE_ENV === 'production'
     ? productionSchema.parse(process.env)

--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -10,7 +10,7 @@ import {
   sepolia,
 } from 'viem/chains'
 import { NetworkId } from '../types/networkId'
-import { getConfig } from '../api/config'
+import { getConfig } from '../config'
 
 const networkIdToViemChain: Record<NetworkId, Chain> = {
   [NetworkId['celo-mainnet']]: celo,

--- a/src/runtime/getPositions.e2e.ts
+++ b/src/runtime/getPositions.e2e.ts
@@ -1,17 +1,7 @@
 import { getPositions } from './getPositions'
 import { NetworkId } from '../types/networkId'
-import fs from 'fs'
-import yaml from 'js-yaml'
 
 describe('getPositions', () => {
-  let getTokensInfoUrl: string
-  beforeAll(() => {
-    // use the same API to get tokens info as we use in production
-    const envFileContent = yaml.load(
-      fs.readFileSync('src/api/production.yaml', 'utf8'),
-    ) as Record<string, string>
-    getTokensInfoUrl = envFileContent['GET_TOKENS_INFO_URL']
-  })
   it.each([NetworkId['celo-mainnet'], NetworkId['ethereum-mainnet']])(
     'should get the address positions successfully for networkId %s',
     async (networkId) => {
@@ -19,7 +9,6 @@ describe('getPositions', () => {
         networkId,
         '0x2b8441ef13333ffa955c9ea5ab5b3692da95260d',
         [],
-        getTokensInfoUrl,
       )
       // Simple check to make sure we got some definitions
       expect(positions.length).toBeGreaterThan(0)
@@ -36,7 +25,6 @@ describe('getPositions', () => {
         networkId,
         '0x2b8441ef13333ffa955c9ea5ab5b3692da95260d',
         [appId],
-        getTokensInfoUrl,
       )
       // Simple check to make sure we got some definitions
       expect(positions.length).toBeGreaterThan(0)
@@ -52,7 +40,6 @@ describe('getPositions', () => {
         NetworkId['celo-mainnet'],
         '0x2b8441ef13333ffa955c9ea5ab5b3692da95260d',
         ['does-not-exist'],
-        getTokensInfoUrl,
       ),
     ).rejects.toThrow(
       /No app with id 'does-not-exist' found, available apps: \w+/,
@@ -62,7 +49,6 @@ describe('getPositions', () => {
         NetworkId['ethereum-mainnet'],
         '0x2b8441ef13333ffa955c9ea5ab5b3692da95260d',
         ['does-not-exist'],
-        getTokensInfoUrl,
       ),
     ).rejects.toThrow(
       /No app with id 'does-not-exist' found, available apps: \w+/,

--- a/src/runtime/getPositions.test.ts
+++ b/src/runtime/getPositions.test.ts
@@ -89,7 +89,6 @@ describe(getPositions, () => {
       NetworkId['celo-mainnet'],
       '0x0000000000000000000000000000000000007e57',
       [],
-      'mock-token-info-url',
     )
     expect(positions.length).toBe(1)
     expect(positions.map((p) => p.appId)).toEqual(['locked-celo-test'])
@@ -148,7 +147,6 @@ describe(getPositions, () => {
         NetworkId['celo-mainnet'],
         '0x0000000000000000000000000000000000007e57',
         [],
-        'mock-get-tokens-info-url',
       ),
     ).rejects.toThrow(
       "Positions hook for app 'test-hook' does not implement 'getAppTokenDefinition'. Please implement it to resolve the intermediary app token definition for 0x1e593f1fe7b61c53874b54ec0c59fd0d5eb8621e (celo-mainnet)",
@@ -225,7 +223,6 @@ describe(getPositions, () => {
       NetworkId['op-mainnet'],
       '0x0000000000000000000000000000000000007e57',
       [],
-      'mock-token-info-url',
     )
     expect(positions.length).toBe(1)
     const beefyPosition = positions[0] as AppTokenPosition
@@ -259,7 +256,6 @@ describe(getPositions, () => {
       NetworkId['celo-mainnet'],
       '0x0000000000000000000000000000000000007e57',
       [],
-      'mock-token-info-url',
     )
     expect(positions.length).toBe(1)
     expect(loggerWarnSpy).toHaveBeenCalledTimes(1)
@@ -304,7 +300,6 @@ describe(getPositions, () => {
       NetworkId['celo-mainnet'],
       '0x0000000000000000000000000000000000007e57',
       [],
-      'mock-token-info-url',
     )
     expect(positions.length).toBe(2)
     expect(loggerWarnSpy).toHaveBeenCalledTimes(0)

--- a/src/runtime/getPositions.ts
+++ b/src/runtime/getPositions.ts
@@ -27,6 +27,7 @@ import { NetworkId } from '../types/networkId'
 import { getClient } from './client'
 import { getTokenId } from './getTokenId'
 import { isNative } from './isNative'
+import { getConfig } from '../config'
 
 interface RawTokenInfo {
   address?: string
@@ -398,7 +399,6 @@ export async function getPositions(
   networkId: NetworkId,
   address: string | undefined,
   appIds: string[] = [],
-  getTokensInfoUrl: string,
 ) {
   const hooksByAppId = await getHooks(appIds, 'positions')
 
@@ -424,7 +424,10 @@ export async function getPositions(
   logger.debug({ definitions }, 'positions definitions')
 
   // Get the base tokens info
-  const baseTokensInfo = await getBaseTokensInfo(getTokensInfoUrl, networkId)
+  const baseTokensInfo = await getBaseTokensInfo(
+    getConfig().GET_TOKENS_INFO_URL,
+    networkId,
+  )
 
   let unlistedBaseTokensInfo: TokensInfo = {}
   let definitionsToResolve: AppPositionDefinition[] = definitions


### PR DESCRIPTION
## Main Changes
1. Config moved outside of the API folder
2. Simplification of `getPositions` function
3. Consistency in config values
4. Improved developer experience

## Details

### 1. Config moved outside of the API folder
The config is now more universally accessible and not limited to the API. The `getClient` function, located outside of the API folder, was already accessing it from the runtime.

### 2. Simplification of `getPositions` function
Removed the need to pass `GET_TOKEN_INFO_URL` to `getPositions`, simplifying its usage.

### 3. Consistency in config values
There was a mismatch with the `getPositions` script, which was passing a default value for `GET_TOKEN_INFO_URL` that differed from the defaults set in `production.yaml` and `staging.yaml`. This caused the $ price to be unavailable during development. Now, all components read the same config, ensuring consistency and proper defaults for development.

### 4. Improved developer experience
With these updates, running `yarn start` or `yarn getPositions ...` works out-of-the-box after cloning the repo, providing a smoother experience for developers.