### PR TITLE
feat: support polygon, base and their testnet

### DIFF
--- a/src/apps/aave/positions.ts
+++ b/src/apps/aave/positions.ts
@@ -48,6 +48,19 @@ const AAVE_V3_ADDRESSES_BY_NETWORK_ID: Record<
     poolAddressesProvider: '0x36616cf17557639614c1cddb356b1b83fc0b2132',
     uiPoolDataProvider: '0x86e2938dae289763d4e09a7e42c5ccca62cf9809',
   },
+  [NetworkId['polygon-pos-mainnet']]: {
+    poolAddressesProvider: '0xa97684ead0e402dc232d5a977953df7ecbab3cdb',
+    uiPoolDataProvider: '0xc69728f11e9e6127733751c8410432913123acf1',
+  },
+  [NetworkId['polygon-pos-amoy']]: undefined,
+  [NetworkId['base-mainnet']]: {
+    poolAddressesProvider: '0xe20fcbdbffc4dd138ce8b2e6fbb6cb49777ad64d',
+    uiPoolDataProvider: '0x174446a6741300cd2e7c1b1a636fee99c8f83502',
+  },
+  [NetworkId['base-sepolia']]: {
+    poolAddressesProvider: '0xd449fed49d9c443688d6816fe6872f21402e41de',
+    uiPoolDataProvider: '0x884702e4b1d0a2900369e83d5765d537f469cac9',
+  },
 }
 
 const AAVE_LOGO =

--- a/src/apps/aave/shortcuts.ts
+++ b/src/apps/aave/shortcuts.ts
@@ -23,6 +23,11 @@ const AAVE_POOL_V3_ADDRESS_BY_NETWORK_ID: {
   [NetworkId['arbitrum-sepolia']]: '0xbfc91d59fdaa134a4ed45f7b584caf96d7792eff',
   [NetworkId['op-mainnet']]: '0x794a61358d6845594f94dc1db02a252b5b4814ad',
   [NetworkId['op-sepolia']]: '0xb50201558b00496a145fe76f7424749556e326d8',
+  [NetworkId['polygon-pos-mainnet']]:
+    '0x794a61358d6845594f94dc1db02a252b5b4814ad',
+  [NetworkId['polygon-pos-amoy']]: undefined,
+  [NetworkId['base-mainnet']]: '0xa238dd80c259a72e81d7e4664a9801593f98d1c5',
+  [NetworkId['base-sepolia']]: '0x07ea79f68b2b3df564d0a34f8e19d9b1e339814b',
 }
 
 // Hardcoding for now

--- a/src/apps/beefy/api.ts
+++ b/src/apps/beefy/api.ts
@@ -35,10 +35,14 @@ export const NETWORK_ID_TO_BEEFY_BLOCKCHAIN_ID: Record<
   [NetworkId['ethereum-mainnet']]: 'ethereum',
   [NetworkId['arbitrum-one']]: 'arbitrum',
   [NetworkId['op-mainnet']]: 'optimism',
+  [NetworkId['polygon-pos-mainnet']]: 'polygon',
+  [NetworkId['base-mainnet']]: 'base',
+  [NetworkId['celo-alfajores']]: null,
   [NetworkId['ethereum-sepolia']]: null,
   [NetworkId['arbitrum-sepolia']]: null,
   [NetworkId['op-sepolia']]: null,
-  [NetworkId['celo-alfajores']]: null,
+  [NetworkId['polygon-pos-amoy']]: null,
+  [NetworkId['base-sepolia']]: null,
 }
 
 export async function getAllBeefyVaults(): Promise<BeefyVault[]> {

--- a/src/apps/beefy/positions.ts
+++ b/src/apps/beefy/positions.ts
@@ -31,14 +31,15 @@ const BEEFY_MULTICALL_ADDRESS: {
   [NetworkId['arbitrum-one']]: '0x47bec05dC291e61cd4360322eA44882cA468dD54',
   [NetworkId['op-mainnet']]: '0xB089f6c9C99238FC6df256cc66d53Aed198584D9',
   [NetworkId['celo-mainnet']]: '0x0bF5F48d8F761efAe0f187eCce60784e5d3E87E6',
-
-  // polygon: 0x244908D9A21B143911D531cD1D37575D63da4D87
-  // base: 0x09C74A4bd3453e1C15D6624F24b3A02059a4dA15
-
+  [NetworkId['polygon-pos-mainnet']]:
+    '0x244908D9A21B143911D531cD1D37575D63da4D87',
+  [NetworkId['base-mainnet']]: '0x09C74A4bd3453e1C15D6624F24b3A02059a4dA15',
   [NetworkId['ethereum-sepolia']]: undefined,
   [NetworkId['arbitrum-sepolia']]: undefined,
   [NetworkId['op-sepolia']]: undefined,
   [NetworkId['celo-alfajores']]: undefined,
+  [NetworkId['polygon-pos-amoy']]: undefined,
+  [NetworkId['base-sepolia']]: undefined,
 }
 
 const beefyAppTokenDefinition = (

--- a/src/apps/curve/positions.ts
+++ b/src/apps/curve/positions.ts
@@ -47,10 +47,14 @@ const NETWORK_ID_TO_CURVE_BLOCKCHAIN_ID: Record<NetworkId, string | null> = {
   [NetworkId['ethereum-mainnet']]: 'ethereum',
   [NetworkId['arbitrum-one']]: 'arbitrum',
   [NetworkId['op-mainnet']]: 'optimism',
+  [NetworkId['polygon-pos-mainnet']]: 'polygon',
+  [NetworkId['base-mainnet']]: 'base',
+  [NetworkId['celo-alfajores']]: null,
   [NetworkId['ethereum-sepolia']]: null,
   [NetworkId['arbitrum-sepolia']]: null,
   [NetworkId['op-sepolia']]: null,
-  [NetworkId['celo-alfajores']]: null,
+  [NetworkId['polygon-pos-amoy']]: null,
+  [NetworkId['base-sepolia']]: null,
 }
 
 export async function getAllCurvePools(

--- a/src/apps/stake-dao/positions.ts
+++ b/src/apps/stake-dao/positions.ts
@@ -41,6 +41,10 @@ const SD_VAULT_ADDRESSES_BY_NETWORK_ID: Record<NetworkId, Address[]> = {
   [NetworkId['arbitrum-sepolia']]: [],
   [NetworkId['op-mainnet']]: [],
   [NetworkId['op-sepolia']]: [],
+  [NetworkId['polygon-pos-mainnet']]: [],
+  [NetworkId['polygon-pos-amoy']]: [],
+  [NetworkId['base-mainnet']]: [],
+  [NetworkId['base-sepolia']]: [],
 }
 
 async function getVaultPositionDefinitions(

--- a/src/apps/uniswap/positions.ts
+++ b/src/apps/uniswap/positions.ts
@@ -48,10 +48,15 @@ const UNI_V3_ADDRESSES_BY_NETWORK_ID: {
     nftPositions: '0xc36442b4a4522e871399cd717abdd847ab11fe88',
     userPositionsMulticall: '0xd983fe1235a4c9006ef65eceed7c33069ad35ad0',
   },
+  [NetworkId['polygon-pos-mainnet']]: undefined, // TODO: ask Gonza to deploy the multicall
+  [NetworkId['base-mainnet']]: undefined, // TODO: ask Gonza to deploy the multicall
+
   [NetworkId['ethereum-sepolia']]: undefined,
   [NetworkId['arbitrum-sepolia']]: undefined,
   [NetworkId['op-sepolia']]: undefined,
   [NetworkId['celo-alfajores']]: undefined,
+  [NetworkId['polygon-pos-amoy']]: undefined,
+  [NetworkId['base-sepolia']]: undefined,
 }
 
 export async function getUniswapV3PositionDefinitions(

--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -8,6 +8,10 @@ import {
   optimism,
   optimismSepolia,
   sepolia,
+  polygon,
+  polygonAmoy,
+  base,
+  baseSepolia,
 } from 'viem/chains'
 import { NetworkId } from '../types/networkId'
 import { getConfig } from '../config'
@@ -21,6 +25,10 @@ const networkIdToViemChain: Record<NetworkId, Chain> = {
   [NetworkId['ethereum-sepolia']]: sepolia,
   [NetworkId['arbitrum-sepolia']]: arbitrumSepolia,
   [NetworkId['op-sepolia']]: optimismSepolia,
+  [NetworkId['polygon-pos-mainnet']]: polygon,
+  [NetworkId['polygon-pos-amoy']]: polygonAmoy,
+  [NetworkId['base-mainnet']]: base,
+  [NetworkId['base-sepolia']]: baseSepolia,
 }
 
 export function getClient(

--- a/src/runtime/isNative.ts
+++ b/src/runtime/isNative.ts
@@ -11,6 +11,10 @@ const networkIdToNativeAssetAddress: Record<NetworkId, string> = {
   [NetworkId['ethereum-sepolia']]: ETHER_HEX_IDENTIFIER,
   [NetworkId['celo-mainnet']]: '0x471ece3750da237f93b8e339c536989b8978a438',
   [NetworkId['celo-alfajores']]: '0xf194afdf50b03e69bd7d057c1aa9e10c9954e4c9',
+  [NetworkId['polygon-pos-mainnet']]: ETHER_HEX_IDENTIFIER,
+  [NetworkId['polygon-pos-amoy']]: ETHER_HEX_IDENTIFIER,
+  [NetworkId['base-mainnet']]: ETHER_HEX_IDENTIFIER,
+  [NetworkId['base-sepolia']]: ETHER_HEX_IDENTIFIER,
 }
 
 export function isNative({

--- a/src/types/networkId.ts
+++ b/src/types/networkId.ts
@@ -12,6 +12,10 @@ export enum NetworkId {
   'arbitrum-sepolia' = 'arbitrum-sepolia',
   'op-mainnet' = 'op-mainnet',
   'op-sepolia' = 'op-sepolia',
+  'polygon-pos-mainnet' = 'polygon-pos-mainnet',
+  'polygon-pos-amoy' = 'polygon-pos-amoy',
+  'base-mainnet' = 'base-mainnet',
+  'base-sepolia' = 'base-sepolia',
 }
 
 export const legacyNetworkToNetworkId: Record<LegacyNetwork, NetworkId> = {


### PR DESCRIPTION
This is a quick change to unblock all requests failing since the wallet is now doing requests with `base` as `networkId`.

I'll update the test account to have a few positions too on these networks and will update the e2e tests separately.