### PR TITLE
feat: consistent args for shortcuts

### DIFF
--- a/src/api/index.test.ts
+++ b/src/api/index.test.ts
@@ -74,6 +74,7 @@ const TEST_POSITIONS_CELO: Position[] = [
     balance: '160.006517430032680046' as SerializedDecimalNumber,
     supply: '170.324243277473535226' as SerializedDecimalNumber,
     availableShortcutIds: [],
+    shortcutTriggerArgs: {},
   },
 ]
 
@@ -124,6 +125,7 @@ const TEST_POSITIONS_ETHEREUM: Position[] = [
     balance: '100.01' as SerializedDecimalNumber,
     supply: '170.10' as SerializedDecimalNumber,
     availableShortcutIds: [],
+    shortcutTriggerArgs: {},
   },
 ]
 
@@ -175,6 +177,7 @@ const TEST_POSITIONS_ARBITRUM: Position[] = [
     balance: '0' as SerializedDecimalNumber,
     supply: '239859963.713137' as SerializedDecimalNumber,
     availableShortcutIds: ['deposit', 'withdraw'],
+    shortcutTriggerArgs: {},
   },
 ]
 
@@ -226,6 +229,7 @@ const TEST_POSITIONS_CELO_EARN: Position[] = [
     balance: '0' as SerializedDecimalNumber,
     supply: '239859963.713137' as SerializedDecimalNumber,
     availableShortcutIds: ['deposit', 'withdraw'],
+    shortcutTriggerArgs: {},
   },
 ]
 

--- a/src/apps/aave/positions.ts
+++ b/src/apps/aave/positions.ts
@@ -151,6 +151,20 @@ const hook: PositionsHook = {
               { address: reserveData.underlyingAsset.toLowerCase(), networkId },
             ],
             availableShortcutIds: ['deposit', 'withdraw'],
+            shortcutTriggerArgs: {
+              deposit: {
+                token: {
+                  address: reserveData.underlyingAsset.toLowerCase(),
+                  decimals: Number(reserveData.decimals),
+                },
+              },
+              withdraw: {
+                token: {
+                  address: reserveData.aTokenAddress.toLowerCase(),
+                  decimals: lpTokenDecimals[i],
+                },
+              },
+            },
             displayProps: {
               title: reserveData.symbol,
               description: `Supplied (APY: ${supplyApy.toFixed(2)}%)`,

--- a/src/apps/aave/shortcuts.ts
+++ b/src/apps/aave/shortcuts.ts
@@ -32,22 +32,22 @@ const hook: ShortcutsHook = {
         name: 'Deposit',
         description: 'Lend your assets to earn interest',
         networkIds: [networkId],
-        // category: 'deposit',
+        category: 'deposit',
         triggerInputShape: {
           token: z.object({
             // TODO: consider requiring only tokenId and (decimal) amount
             // Right now it would mean more changes in hooks
             address: ZodAddressLowerCased,
             decimals: z.coerce.number(),
-            amount: z.string(), // in decimal string
           }),
+          amount: z.string(), // in decimal string
         },
-        async onTrigger({ networkId, address, token }) {
+        async onTrigger({ networkId, address, token, amount }) {
           const walletAddress = address as Address
           const transactions: Transaction[] = []
 
           // amount in smallest unit
-          const amountToSupply = parseUnits(token.amount, token.decimals)
+          const amountToSupply = parseUnits(amount, token.decimals)
 
           const client = getClient(networkId)
 
@@ -99,7 +99,7 @@ const hook: ShortcutsHook = {
         name: 'Withdraw',
         description: 'Withdraw your assets',
         networkIds: [networkId],
-        // category: 'withdraw',
+        category: 'withdraw',
         triggerInputShape: {
           // This is the A token
           token: z.object({
@@ -107,15 +107,15 @@ const hook: ShortcutsHook = {
             // Right now it would mean more changes in hooks
             address: ZodAddressLowerCased,
             decimals: z.coerce.number(),
-            amount: z.string(), // in decimal string
           }),
+          amount: z.string(), // in decimal string
         },
-        async onTrigger({ networkId, address, token }) {
+        async onTrigger({ networkId, address, token, amount }) {
           const walletAddress = address as Address
           const transactions: Transaction[] = []
 
           // amount in smallest unit
-          const amountToWithdraw = parseUnits(token.amount, token.decimals)
+          const amountToWithdraw = parseUnits(amount, token.decimals)
 
           const client = getClient(networkId)
 

--- a/src/apps/allbridge/positions.ts
+++ b/src/apps/allbridge/positions.ts
@@ -106,6 +106,21 @@ const hook: PositionsHook = {
               { address: tokenInfo.tokenAddress.toLowerCase(), networkId },
             ],
             availableShortcutIds: ['deposit', 'withdraw'],
+            shortcutTriggerArgs: {
+              deposit: {
+                token: {
+                  address: tokenInfo.tokenAddress.toLowerCase(),
+                  decimals: tokenInfo.decimals,
+                },
+                positionAddress: tokenInfo.poolAddress.toLowerCase(),
+              },
+              withdraw: {
+                token: {
+                  decimals: tokenInfo.decimals,
+                },
+                positionAddress: tokenInfo.poolAddress.toLowerCase(),
+              },
+            },
             displayProps: {
               title: tokenInfo.symbol,
               description: `Supplied (APR: ${apr.toFixed(2)}%)`,
@@ -173,6 +188,11 @@ const hook: PositionsHook = {
               },
             ],
             availableShortcutIds: ['claim-rewards'],
+            shortcutTriggerArgs: {
+              'claim-rewards': {
+                positionAddress: tokenInfo.poolAddress.toLowerCase(),
+              },
+            },
             balances: [toDecimalNumber(pendingReward, tokenInfo.decimals)],
             displayProps: {
               title: `${tokenInfo.symbol} supply incentives`,

--- a/src/apps/allbridge/shortcuts.ts
+++ b/src/apps/allbridge/shortcuts.ts
@@ -21,24 +21,30 @@ const hook: ShortcutsHook = {
         name: 'Deposit',
         description: 'Lend your assets to earn interest',
         networkIds: [networkId],
-        // category: 'deposit',
+        category: 'deposit',
         triggerInputShape: {
           token: z.object({
             // TODO: consider requiring only tokenId and (decimal) amount
             // Right now it would mean more changes in hooks
             address: ZodAddressLowerCased,
             decimals: z.coerce.number(),
-            amount: z.string(), // in decimal string
           }),
           positionAddress: ZodAddressLowerCased,
+          amount: z.string(), // in decimal string
         },
 
-        async onTrigger({ networkId, address, token, positionAddress }) {
+        async onTrigger({
+          networkId,
+          address,
+          token,
+          positionAddress,
+          amount,
+        }) {
           const walletAddress = address as Address
           const transactions: Transaction[] = []
 
           // amount in smallest unit
-          const amountToSupply = parseUnits(token.amount, token.decimals)
+          const amountToSupply = parseUnits(amount, token.decimals)
 
           const client = getClient(networkId)
 
@@ -90,12 +96,14 @@ const hook: ShortcutsHook = {
         name: 'Withdraw',
         description: 'Withdraw your assets',
         networkIds: [networkId],
+        category: 'withdraw',
         triggerInputShape: {
           token: z.object({
             decimals: z.coerce.number(),
             amount: z.string(),
           }),
           positionAddress: ZodAddressLowerCased,
+          amount: z.string(),
         },
         async onTrigger({ networkId, address, token, positionAddress }) {
           const walletAddress = address as Address

--- a/src/runtime/getPositions.ts
+++ b/src/runtime/getPositions.ts
@@ -306,6 +306,7 @@ async function resolveAppTokenPosition(
     balance: toSerializedDecimalNumber(positionTokenInfo.balance),
     supply: toSerializedDecimalNumber(positionTokenInfo.totalSupply),
     availableShortcutIds: positionDefinition.availableShortcutIds ?? [],
+    shortcutTriggerArgs: positionDefinition.shortcutTriggerArgs ?? {},
   }
 
   return position
@@ -373,6 +374,7 @@ async function resolveContractPosition(
     tokens: tokens,
     balanceUsd: toSerializedDecimalNumber(balanceUsd),
     availableShortcutIds: positionDefinition.availableShortcutIds ?? [],
+    shortcutTriggerArgs: positionDefinition.shortcutTriggerArgs ?? {},
   }
 
   return position

--- a/src/types/positions.ts
+++ b/src/types/positions.ts
@@ -102,6 +102,10 @@ export interface AbstractPositionDefinition {
   })[]
 
   availableShortcutIds?: string[] // Allows to apply shortcuts to positions
+  shortcutTriggerArgs?: {
+    // A map of shortcutId to trigger args
+    [shortcutId in string]?: Record<string, any>
+  }
 }
 
 export interface PricePerShareContext {
@@ -157,6 +161,10 @@ export interface AbstractPosition {
   dataProps?: DataProps
   tokens: (Token & { category?: TokenCategory })[]
   availableShortcutIds: string[] // Allows to apply shortcuts to positions
+  shortcutTriggerArgs: {
+    // A map of shortcutId to trigger args
+    [shortcutId in string]?: Record<string, any>
+  }
 }
 
 export interface AbstractToken {

--- a/src/types/shortcuts.ts
+++ b/src/types/shortcuts.ts
@@ -1,25 +1,34 @@
 import { z, ZodObject, ZodRawShape } from 'zod'
 import { NetworkId } from './networkId'
 
+export type ShortcutCategory = 'claim' | 'deposit' | 'withdraw'
+
 export interface ShortcutsHook {
   getShortcutDefinitions(
     networkId: NetworkId,
     address?: string,
-  ): Promise<ShortcutDefinition<any>[]>
+  ): Promise<ShortcutDefinition<ShortcutCategory, any>[]>
 }
 
-export interface ShortcutDefinition<TriggerInputShape extends ZodRawShape> {
+type TriggerInputShape<Category> = Category extends 'deposit' | 'withdraw'
+  ? ZodRawShape & { amount: z.ZodString }
+  : ZodRawShape
+
+export interface ShortcutDefinition<
+  Category extends ShortcutCategory,
+  InputShape extends TriggerInputShape<Category>,
+> {
   id: string // Example: claim-reward
   name: string // Example: Claim
   description: string // Example: Claim your reward
   networkIds: NetworkId[] // Example: ['celo-mainnet']
-  category?: 'claim' // We'll add more categories later
-  triggerInputShape: TriggerInputShape // Zod object shape of the input for the trigger
+  category: Category
+  triggerInputShape: InputShape
   onTrigger: (
     args: {
       networkId: NetworkId
       address: string
-    } & z.infer<ZodObject<TriggerInputShape>>,
+    } & z.infer<ZodObject<InputShape>>,
   ) => Promise<Transaction[]> // 0, 1 or more transactions to sign by the user
 }
 
@@ -35,8 +44,9 @@ export type Transaction = {
 
 // This is to help TS infer the type of the triggerInputShape
 // so the onTrigger args can be properly typed
-export function createShortcut<TriggerInputShape extends ZodRawShape>(
-  definition: ShortcutDefinition<TriggerInputShape>,
-) {
+export function createShortcut<
+  Category extends ShortcutCategory,
+  InputShape extends TriggerInputShape<Category>,
+>(definition: ShortcutDefinition<Category, InputShape>) {
   return definition
 }


### PR DESCRIPTION
For clients to call deposit / withdraw / claim shorts for different providers, we need consistent input parameters for different providers. This updates position definitions to define a shortcutTriggerArgs that can be passed as is to `triggerShortcut`. Additionally, enforces `amount` on deposit / withdraw shortcuts as this needs to come from the client.