### PR TITLE
fix(aave): incorrect rewards

### DIFF
--- a/src/apps/aave/getAaveTokensWithIncentives.ts
+++ b/src/apps/aave/getAaveTokensWithIncentives.ts
@@ -1,0 +1,33 @@
+import { Address } from 'viem'
+
+interface IncentiveData {
+  readonly tokenAddress: Address
+  readonly rewardsTokenInformation: readonly any[]
+}
+
+// Just a subset of the actual data
+interface ReserveIncentivesData {
+  readonly aIncentiveData: IncentiveData
+  readonly vIncentiveData: IncentiveData
+  readonly sIncentiveData: IncentiveData
+}
+
+export function getAaveTokensWithIncentives(
+  reservesIncentiveData: readonly ReserveIncentivesData[],
+): Address[] {
+  return reservesIncentiveData
+    .map(({ aIncentiveData, vIncentiveData, sIncentiveData }) => {
+      const assetsWithRewards: Address[] = []
+      if (aIncentiveData.rewardsTokenInformation.length) {
+        assetsWithRewards.push(aIncentiveData.tokenAddress)
+      }
+      if (vIncentiveData.rewardsTokenInformation.length) {
+        assetsWithRewards.push(vIncentiveData.tokenAddress)
+      }
+      if (sIncentiveData.rewardsTokenInformation.length) {
+        assetsWithRewards.push(sIncentiveData.tokenAddress)
+      }
+      return assetsWithRewards
+    })
+    .flat()
+}

--- a/src/apps/aave/positions.ts
+++ b/src/apps/aave/positions.ts
@@ -86,7 +86,7 @@ const hook: PositionsHook = {
         : [undefined, [undefined, undefined]]
 
     // Note: Instead of calling `getAllUserRewards`, we could use reserveIncentiveData and userIncentivesData to get all user rewards
-    // but it requires some additional calculations to get the accrued rewards (linked to a/v/sToken held) and the unclaimedRewards.
+    // but it requires some additional calculations to get the accrued rewards (linked to a/v/sToken held) on top of the unclaimedRewards to get total rewards.
     // This is for simplicity here.
     // See https://github.com/aave/aave-utilities/blob/446d9af6f14154771c0343538b59e2aeb7b38e47/packages/math-utils/src/formatters/incentive/calculate-all-user-incentives.ts#L31
     const allUserRewards = await client.readContract({

--- a/src/apps/aave/positions.ts
+++ b/src/apps/aave/positions.ts
@@ -26,6 +26,7 @@ import {
 } from './constants'
 import { aTokenAbi } from './abis/atoken'
 import { incentivesControllerV3Abi } from './abis/incentives-controller-v3'
+import { getAaveTokensWithIncentives } from './getAaveTokensWithIncentives'
 
 const COMPOUND_PERIOD = 365 * 24 * 60 * 60 // 1 year in seconds
 
@@ -97,21 +98,7 @@ const hook: PositionsHook = {
           args: [
             // This builds the list of a/v/sToken address with incentives
             // Because `getAllUserRewards` reverts if we pass an address with no incentives
-            reserveIncentiveData
-              ?.map(({ aIncentiveData, vIncentiveData, sIncentiveData }) => {
-                const assetsWithRewards: Address[] = []
-                if (aIncentiveData.rewardsTokenInformation.length) {
-                  assetsWithRewards.push(aIncentiveData.tokenAddress)
-                }
-                if (vIncentiveData.rewardsTokenInformation.length) {
-                  assetsWithRewards.push(vIncentiveData.tokenAddress)
-                }
-                if (sIncentiveData.rewardsTokenInformation.length) {
-                  assetsWithRewards.push(sIncentiveData.tokenAddress)
-                }
-                return assetsWithRewards
-              })
-              .flat() || [],
+            getAaveTokensWithIncentives(reserveIncentiveData ?? []),
             address as Address,
           ],
         })

--- a/src/apps/aave/positions.ts
+++ b/src/apps/aave/positions.ts
@@ -25,6 +25,7 @@ import {
   NETWORK_ID_TO_AAVE_MARKET_NAME,
 } from './constants'
 import { aTokenAbi } from './abis/atoken'
+import { incentivesControllerV3Abi } from './abis/incentives-controller-v3'
 
 const COMPOUND_PERIOD = 365 * 24 * 60 * 60 // 1 year in seconds
 
@@ -63,25 +64,57 @@ const hook: PositionsHook = {
       args: [aaveAddresses.poolAddressesProvider],
     })
 
-    const [userReserveData, userIncentivesData] = address
-      ? await client.multicall({
-          contracts: [
-            {
-              address: aaveAddresses.uiPoolDataProvider,
-              abi: uiPoolDataProviderV3Abi,
-              functionName: 'getUserReservesData',
-              args: [aaveAddresses.poolAddressesProvider, address as Address],
-            },
-            {
-              address: aaveAddresses.uiIncentiveDataProvider,
-              abi: uiIncentiveDataProviderV3Abi,
-              functionName: 'getUserReservesIncentivesData',
-              args: [aaveAddresses.poolAddressesProvider, address as Address],
-            },
-          ],
-          allowFailure: false,
-        })
-      : [undefined, undefined]
+    const [userReserveData, [reserveIncentiveData, _userIncentivesData]] =
+      address
+        ? await client.multicall({
+            contracts: [
+              {
+                address: aaveAddresses.uiPoolDataProvider,
+                abi: uiPoolDataProviderV3Abi,
+                functionName: 'getUserReservesData',
+                args: [aaveAddresses.poolAddressesProvider, address as Address],
+              },
+              {
+                address: aaveAddresses.uiIncentiveDataProvider,
+                abi: uiIncentiveDataProviderV3Abi,
+                functionName: 'getFullReservesIncentiveData',
+                args: [aaveAddresses.poolAddressesProvider, address as Address],
+              },
+            ],
+            allowFailure: false,
+          })
+        : [undefined, [undefined, undefined]]
+
+    // Note: Instead of calling `getAllUserRewards`, we could use reserveIncentiveData and userIncentivesData to get all user rewards
+    // but it requires some additional calculations to get the accrued rewards (linked to a/v/sToken held) and the unclaimedRewards.
+    // This is for simplicity here.
+    // See https://github.com/aave/aave-utilities/blob/446d9af6f14154771c0343538b59e2aeb7b38e47/packages/math-utils/src/formatters/incentive/calculate-all-user-incentives.ts#L31
+    const allUserRewards = await client.readContract({
+      address: aaveAddresses.incentivesController,
+      abi: incentivesControllerV3Abi,
+      functionName: 'getAllUserRewards',
+      args: [
+        // This builds the list of a/v/sToken address with incentives
+        // Because `getAllUserRewards` reverts if we pass an address with no incentives
+        reserveIncentiveData
+          ?.map(({ aIncentiveData, vIncentiveData, sIncentiveData }) => {
+            const assetsWithRewards: Address[] = []
+            if (aIncentiveData.rewardsTokenInformation.length) {
+              assetsWithRewards.push(aIncentiveData.tokenAddress)
+            }
+            if (vIncentiveData.rewardsTokenInformation.length) {
+              assetsWithRewards.push(vIncentiveData.tokenAddress)
+            }
+            if (sIncentiveData.rewardsTokenInformation.length) {
+              assetsWithRewards.push(sIncentiveData.tokenAddress)
+            }
+            return assetsWithRewards
+          })
+          .flat() || [],
+        address as Address,
+      ],
+    })
+    const [rewardTokenAddresses, rewardTokenAmounts] = allUserRewards
 
     const [totalSupplies, lpTokenDecimals] = await Promise.all([
       Promise.all(
@@ -111,211 +144,141 @@ const hook: PositionsHook = {
       (NETWORK_ID_TO_AAVE_MARKET_NAME[networkId]
         ? `?marketName=${NETWORK_ID_TO_AAVE_MARKET_NAME[networkId]}`
         : '')
-    return reservesData.flatMap((reserveData, i) => {
-      const supplyApy = getApyFromRayApr(reserveData.liquidityRate)
-      const variableBorrowApy = getApyFromRayApr(reserveData.variableBorrowRate)
-      const stableBorrowApy = getApyFromRayApr(
-        userReserveData?.[i].stableBorrowRate || reserveData.stableBorrowRate,
-      )
-
-      // Include a token if the user has a balance
-      // or if no user data is available (when querying all positions)
-      const useAToken =
-        !userReserveData || userReserveData[i].scaledATokenBalance > 0n
-      const useVariableDebt =
-        !userReserveData || userReserveData[i].scaledVariableDebt > 0n
-      const useStableDebt =
-        !userReserveData || userReserveData[i].principalStableDebt > 0n
-
-      const userIncentives = userIncentivesData?.[i]
-      const aTokenRewardsInfo =
-        userIncentives?.aTokenIncentivesUserData.userRewardsInformation.filter(
-          (info) => info.userUnclaimedRewards > 0n,
+    return [
+      reservesData.flatMap((reserveData, i) => {
+        const supplyApy = getApyFromRayApr(reserveData.liquidityRate)
+        const variableBorrowApy = getApyFromRayApr(
+          reserveData.variableBorrowRate,
         )
-      const variableDebtRewardsInfo =
-        userIncentives?.vTokenIncentivesUserData.userRewardsInformation.filter(
-          (info) => info.userUnclaimedRewards > 0n,
-        )
-      const stableDebtRewardsInfo =
-        userIncentives?.sTokenIncentivesUserData.userRewardsInformation.filter(
-          (info) => info.userUnclaimedRewards > 0n,
+        const stableBorrowApy = getApyFromRayApr(
+          userReserveData?.[i].stableBorrowRate || reserveData.stableBorrowRate,
         )
 
-      return [
-        // AToken
-        useAToken &&
-          ({
-            type: 'app-token-definition',
-            networkId,
-            address: reserveData.aTokenAddress.toLowerCase(),
-            tokens: [
-              { address: reserveData.underlyingAsset.toLowerCase(), networkId },
-            ],
-            availableShortcutIds: ['deposit', 'withdraw'],
-            displayProps: {
-              title: reserveData.symbol,
-              description: `Supplied (APY: ${supplyApy.toFixed(2)}%)`,
-              imageUrl: AAVE_LOGO,
-            },
-            dataProps: {
-              manageUrl,
-              termsUrl: AAVE_TERMS_URL,
-              contractCreatedAt:
-                AAVE_CONTRACT_CREATED_AT[
-                  getTokenId({
-                    networkId,
-                    address: reserveData.aTokenAddress.toLowerCase(),
-                  })
-                ],
-              tvl: toSerializedDecimalNumber(
-                toDecimalNumber(totalSupplies[i], lpTokenDecimals[i]),
-              ),
-              yieldRates: [
+        // Include a token if the user has a balance
+        // or if no user data is available (when querying all positions)
+        const useAToken =
+          !userReserveData || userReserveData[i].scaledATokenBalance > 0n
+        const useVariableDebt =
+          !userReserveData || userReserveData[i].scaledVariableDebt > 0n
+        const useStableDebt =
+          !userReserveData || userReserveData[i].principalStableDebt > 0n
+
+        return [
+          // AToken
+          useAToken &&
+            ({
+              type: 'app-token-definition',
+              networkId,
+              address: reserveData.aTokenAddress.toLowerCase(),
+              tokens: [
                 {
-                  percentage: supplyApy,
-                  label: t('yieldRates.earningsApy'),
-                  tokenId: getTokenId({
-                    networkId,
-                    address: reserveData.underlyingAsset.toLowerCase(),
-                  }),
+                  address: reserveData.underlyingAsset.toLowerCase(),
+                  networkId,
                 },
               ],
-              earningItems: aTokenRewardsInfo?.length
-                ? aTokenRewardsInfo.map((info) => ({
-                    amount: toDecimalNumber(
-                      info.userUnclaimedRewards,
-                      info.rewardTokenDecimals,
-                    ),
-                    label: t('earningItems.rewards'),
+              availableShortcutIds: ['deposit', 'withdraw'],
+              displayProps: {
+                title: reserveData.symbol,
+                description: `Supplied (APY: ${supplyApy.toFixed(2)}%)`,
+                imageUrl: AAVE_LOGO,
+              },
+              dataProps: {
+                manageUrl,
+                termsUrl: AAVE_TERMS_URL,
+                contractCreatedAt:
+                  AAVE_CONTRACT_CREATED_AT[
+                    getTokenId({
+                      networkId,
+                      address: reserveData.aTokenAddress.toLowerCase(),
+                    })
+                  ],
+                tvl: toSerializedDecimalNumber(
+                  toDecimalNumber(totalSupplies[i], lpTokenDecimals[i]),
+                ),
+                yieldRates: [
+                  {
+                    percentage: supplyApy,
+                    label: t('yieldRates.earningsApy'),
                     tokenId: getTokenId({
                       networkId,
-                      address: info.rewardTokenAddress.toLowerCase(),
+                      address: reserveData.underlyingAsset.toLowerCase(),
                     }),
-                  }))
-                : [],
-              depositTokenId: getTokenId({
+                  },
+                ],
+                earningItems: [],
+                depositTokenId: getTokenId({
+                  networkId,
+                  address: reserveData.underlyingAsset.toLowerCase(),
+                }),
+                withdrawTokenId: getTokenId({
+                  networkId,
+                  address: reserveData.aTokenAddress.toLowerCase(),
+                }),
+              },
+              pricePerShare: [new BigNumber(1) as DecimalNumber],
+            } satisfies AppTokenPositionDefinition),
+          // Variable debt token
+          useVariableDebt &&
+            ({
+              type: 'app-token-definition',
+              networkId,
+              address: reserveData.variableDebtTokenAddress.toLowerCase(),
+              tokens: [{ address: reserveData.underlyingAsset, networkId }],
+              displayProps: {
+                title: `${reserveData.symbol} debt`,
+                description: `Borrowed variable (APY: ${variableBorrowApy.toFixed(
+                  2,
+                )}%)`,
+                imageUrl: AAVE_LOGO,
+              },
+              // TODO: update runtime so we can specify a negative balance for debt
+              // instead of using a negative pricePerShare
+              pricePerShare: [new BigNumber(-1) as DecimalNumber],
+            } satisfies AppTokenPositionDefinition),
+          // Stable debt token
+          useStableDebt &&
+            ({
+              type: 'app-token-definition',
+              networkId,
+              address: reserveData.stableDebtTokenAddress.toLowerCase(),
+              tokens: [{ address: reserveData.underlyingAsset, networkId }],
+              displayProps: {
+                title: `${reserveData.symbol} debt`,
+                description: `Borrowed stable (APY: ${stableBorrowApy.toFixed(
+                  2,
+                )}%)`,
+                imageUrl: AAVE_LOGO,
+              },
+              // TODO: similar as comment above for variable debt
+              pricePerShare: [new BigNumber(-1) as DecimalNumber],
+            } satisfies AppTokenPositionDefinition),
+        ].filter((x) => !!x)
+      }),
+      // User rewards
+      rewardTokenAddresses.length
+        ? [
+            {
+              type: 'contract-position-definition',
+              networkId,
+              address: aaveAddresses.incentivesController.toLowerCase(),
+              tokens: rewardTokenAddresses.map((rewardTokenAddress) => ({
+                address: rewardTokenAddress.toLowerCase(),
                 networkId,
-                address: reserveData.underlyingAsset.toLowerCase(),
-              }),
-              withdrawTokenId: getTokenId({
-                networkId,
-                address: reserveData.aTokenAddress.toLowerCase(),
-              }),
-            },
-            pricePerShare: [new BigNumber(1) as DecimalNumber],
-          } satisfies AppTokenPositionDefinition),
-        // ATokens incentives
-        aTokenRewardsInfo?.length &&
-          ({
-            type: 'contract-position-definition',
-            networkId,
-            address: reserveData.aTokenAddress.toLowerCase(),
-            extraId: 'supply-incentives',
-            tokens: aTokenRewardsInfo.map((info) => ({
-              address: info.rewardTokenAddress.toLowerCase(),
-              networkId,
-              category: 'claimable',
-            })),
-            availableShortcutIds: ['claim-rewards'],
-            balances: aTokenRewardsInfo.map((info) =>
-              toDecimalNumber(
-                info.userUnclaimedRewards,
-                info.rewardTokenDecimals,
+                category: 'claimable',
+              })),
+              availableShortcutIds: ['claim-rewards'],
+              balances: rewardTokenAmounts.map((rewardTokenAmount) =>
+                toDecimalNumber(rewardTokenAmount, 18),
               ),
-            ),
-            displayProps: {
-              title: `${reserveData.symbol} supply incentives`,
-              description: 'Rewards for supplying',
-              imageUrl: AAVE_LOGO,
-            },
-          } satisfies ContractPositionDefinition),
-        // Variable debt token
-        useVariableDebt &&
-          ({
-            type: 'app-token-definition',
-            networkId,
-            address: reserveData.variableDebtTokenAddress.toLowerCase(),
-            tokens: [{ address: reserveData.underlyingAsset, networkId }],
-            displayProps: {
-              title: `${reserveData.symbol} debt`,
-              description: `Borrowed variable (APY: ${variableBorrowApy.toFixed(
-                2,
-              )}%)`,
-              imageUrl: AAVE_LOGO,
-            },
-            // TODO: update runtime so we can specify a negative balance for debt
-            // instead of using a negative pricePerShare
-            pricePerShare: [new BigNumber(-1) as DecimalNumber],
-          } satisfies AppTokenPositionDefinition),
-        // Variable debt incentives
-        variableDebtRewardsInfo?.length &&
-          ({
-            type: 'contract-position-definition',
-            networkId,
-            address: reserveData.variableDebtTokenAddress.toLowerCase(),
-            extraId: 'variable-debt-incentives',
-            tokens: variableDebtRewardsInfo.map((info) => ({
-              address: info.rewardTokenAddress.toLowerCase(),
-              networkId,
-              category: 'claimable',
-            })),
-            availableShortcutIds: ['claim-rewards'],
-            balances: variableDebtRewardsInfo.map((info) =>
-              toDecimalNumber(
-                info.userUnclaimedRewards,
-                info.rewardTokenDecimals,
-              ),
-            ),
-            displayProps: {
-              title: `${reserveData.symbol} variable debt incentives`,
-              description: 'Rewards for borrowing',
-              imageUrl: AAVE_LOGO,
-            },
-          } satisfies ContractPositionDefinition),
-        // Stable debt token
-        useStableDebt &&
-          ({
-            type: 'app-token-definition',
-            networkId,
-            address: reserveData.stableDebtTokenAddress.toLowerCase(),
-            tokens: [{ address: reserveData.underlyingAsset, networkId }],
-            displayProps: {
-              title: `${reserveData.symbol} debt`,
-              description: `Borrowed stable (APY: ${stableBorrowApy.toFixed(
-                2,
-              )}%)`,
-              imageUrl: AAVE_LOGO,
-            },
-            // TODO: similar as comment above for variable debt
-            pricePerShare: [new BigNumber(-1) as DecimalNumber],
-          } satisfies AppTokenPositionDefinition),
-        // Stable debt incentives
-        stableDebtRewardsInfo?.length &&
-          ({
-            type: 'contract-position-definition',
-            networkId,
-            address: reserveData.stableDebtTokenAddress.toLowerCase(),
-            extraId: 'stable-debt-incentives',
-            tokens: stableDebtRewardsInfo.map((info) => ({
-              address: info.rewardTokenAddress.toLowerCase(),
-              networkId,
-              category: 'claimable',
-            })),
-            availableShortcutIds: ['claim-rewards'],
-            balances: stableDebtRewardsInfo.map((info) =>
-              toDecimalNumber(
-                info.userUnclaimedRewards,
-                info.rewardTokenDecimals,
-              ),
-            ),
-            displayProps: {
-              title: `${reserveData.symbol} stable debt incentives`,
-              description: 'Rewards for borrowing',
-              imageUrl: AAVE_LOGO,
-            },
-          } satisfies ContractPositionDefinition),
-      ].filter((x) => !!x)
-    })
+              displayProps: {
+                title: `Claimable rewards`,
+                description: 'For supplying and borrowing',
+                imageUrl: AAVE_LOGO,
+              },
+            } satisfies ContractPositionDefinition,
+          ]
+        : [],
+    ].flat()
   },
   async getAppTokenDefinition({ networkId, address }: TokenDefinition) {
     throw new UnknownAppTokenError({ networkId, address })

--- a/src/apps/aave/positions.ts
+++ b/src/apps/aave/positions.ts
@@ -89,31 +89,33 @@ const hook: PositionsHook = {
     // but it requires some additional calculations to get the accrued rewards (linked to a/v/sToken held) on top of the unclaimedRewards to get total rewards.
     // This is for simplicity here.
     // See https://github.com/aave/aave-utilities/blob/446d9af6f14154771c0343538b59e2aeb7b38e47/packages/math-utils/src/formatters/incentive/calculate-all-user-incentives.ts#L31
-    const allUserRewards = await client.readContract({
-      address: aaveAddresses.incentivesController,
-      abi: incentivesControllerV3Abi,
-      functionName: 'getAllUserRewards',
-      args: [
-        // This builds the list of a/v/sToken address with incentives
-        // Because `getAllUserRewards` reverts if we pass an address with no incentives
-        reserveIncentiveData
-          ?.map(({ aIncentiveData, vIncentiveData, sIncentiveData }) => {
-            const assetsWithRewards: Address[] = []
-            if (aIncentiveData.rewardsTokenInformation.length) {
-              assetsWithRewards.push(aIncentiveData.tokenAddress)
-            }
-            if (vIncentiveData.rewardsTokenInformation.length) {
-              assetsWithRewards.push(vIncentiveData.tokenAddress)
-            }
-            if (sIncentiveData.rewardsTokenInformation.length) {
-              assetsWithRewards.push(sIncentiveData.tokenAddress)
-            }
-            return assetsWithRewards
-          })
-          .flat() || [],
-        address as Address,
-      ],
-    })
+    const allUserRewards = address
+      ? await client.readContract({
+          address: aaveAddresses.incentivesController,
+          abi: incentivesControllerV3Abi,
+          functionName: 'getAllUserRewards',
+          args: [
+            // This builds the list of a/v/sToken address with incentives
+            // Because `getAllUserRewards` reverts if we pass an address with no incentives
+            reserveIncentiveData
+              ?.map(({ aIncentiveData, vIncentiveData, sIncentiveData }) => {
+                const assetsWithRewards: Address[] = []
+                if (aIncentiveData.rewardsTokenInformation.length) {
+                  assetsWithRewards.push(aIncentiveData.tokenAddress)
+                }
+                if (vIncentiveData.rewardsTokenInformation.length) {
+                  assetsWithRewards.push(vIncentiveData.tokenAddress)
+                }
+                if (sIncentiveData.rewardsTokenInformation.length) {
+                  assetsWithRewards.push(sIncentiveData.tokenAddress)
+                }
+                return assetsWithRewards
+              })
+              .flat() || [],
+            address as Address,
+          ],
+        })
+      : [[], []]
     const [rewardTokenAddresses, rewardTokenAmounts] = allUserRewards
     const userRewards = rewardTokenAddresses
       .map((rewardTokenAddress, i) => ({

--- a/src/apps/aave/shortcuts.ts
+++ b/src/apps/aave/shortcuts.ts
@@ -13,6 +13,7 @@ import { aTokenAbi } from './abis/atoken'
 import { AAVE_V3_ADDRESSES_BY_NETWORK_ID } from './constants'
 import { incentivesControllerV3Abi } from './abis/incentives-controller-v3'
 import { simulateTransactions } from '../../runtime/simulateTransactions'
+import { uiIncentiveDataProviderV3Abi } from './abis/ui-incentive-data-provider'
 
 // Hardcoded fallback if simulation isn't enabled
 const GAS = 1_000_000n
@@ -167,8 +168,35 @@ const hook: ShortcutsHook = {
         triggerInputShape: {
           positionAddress: ZodAddressLowerCased,
         },
-        async onTrigger({ networkId, address, positionAddress }) {
+        async onTrigger({ networkId, address }) {
           const walletAddress = address as Address
+
+          const client = getClient(networkId)
+
+          // Get a/v/sToken for which we can claim rewards
+          const reserveIncentiveData = await client.readContract({
+            address: aaveAddresses.uiIncentiveDataProvider,
+            abi: uiIncentiveDataProviderV3Abi,
+            functionName: 'getReservesIncentivesData',
+            args: [aaveAddresses.poolAddressesProvider],
+          })
+
+          // This builds the list of a/v/sToken address with incentives
+          const assetsWithIncentives = reserveIncentiveData
+            .map(({ aIncentiveData, vIncentiveData, sIncentiveData }) => {
+              const assetsWithRewards: Address[] = []
+              if (aIncentiveData.rewardsTokenInformation.length) {
+                assetsWithRewards.push(aIncentiveData.tokenAddress)
+              }
+              if (vIncentiveData.rewardsTokenInformation.length) {
+                assetsWithRewards.push(vIncentiveData.tokenAddress)
+              }
+              if (sIncentiveData.rewardsTokenInformation.length) {
+                assetsWithRewards.push(sIncentiveData.tokenAddress)
+              }
+              return assetsWithRewards
+            })
+            .flat()
 
           return [
             {
@@ -178,7 +206,7 @@ const hook: ShortcutsHook = {
               data: encodeFunctionData({
                 abi: incentivesControllerV3Abi,
                 functionName: 'claimAllRewardsToSelf',
-                args: [[positionAddress]], // positionAddress is the a/v/sToken address
+                args: [assetsWithIncentives],
               }),
             },
           ]

--- a/src/apps/aave/shortcuts.ts
+++ b/src/apps/aave/shortcuts.ts
@@ -14,6 +14,7 @@ import { AAVE_V3_ADDRESSES_BY_NETWORK_ID } from './constants'
 import { incentivesControllerV3Abi } from './abis/incentives-controller-v3'
 import { simulateTransactions } from '../../runtime/simulateTransactions'
 import { uiIncentiveDataProviderV3Abi } from './abis/ui-incentive-data-provider'
+import { getAaveTokensWithIncentives } from './getAaveTokensWithIncentives'
 
 // Hardcoded fallback if simulation isn't enabled
 const GAS = 1_000_000n
@@ -182,21 +183,8 @@ const hook: ShortcutsHook = {
           })
 
           // This builds the list of a/v/sToken address with incentives
-          const assetsWithIncentives = reserveIncentiveData
-            .map(({ aIncentiveData, vIncentiveData, sIncentiveData }) => {
-              const assetsWithRewards: Address[] = []
-              if (aIncentiveData.rewardsTokenInformation.length) {
-                assetsWithRewards.push(aIncentiveData.tokenAddress)
-              }
-              if (vIncentiveData.rewardsTokenInformation.length) {
-                assetsWithRewards.push(vIncentiveData.tokenAddress)
-              }
-              if (sIncentiveData.rewardsTokenInformation.length) {
-                assetsWithRewards.push(sIncentiveData.tokenAddress)
-              }
-              return assetsWithRewards
-            })
-            .flat()
+          const assetsWithIncentives =
+            getAaveTokensWithIncentives(reserveIncentiveData)
 
           return [
             {


### PR DESCRIPTION
This fixes the incorrect display of rewards for Aave.

The `userRewardsInformation` returned for each a/v/sToken from `getUserReservesIncentivesData`
with `userUnclaimedRewards` can't be used as is and requires some additional calculations to get the total rewards for the user.

In particular if there are multiple Aave assets with incentives yielding a given reward token, the `userUnclaimedRewards` value will be the same across those assets.
And it doesn't include the accrued rewards for the assets currently being held.

The details of these calculations to get the total rewards can be seen in https://github.com/aave/aave-utilities/blob/446d9af6f14154771c0343538b59e2aeb7b38e47/packages/math-utils/src/formatters/incentive/calculate-all-user-incentives.ts#L31

For simplicity we can call `getAllUserRewards` which returns all rewards at once.
Small caveat, we loose the info about which a/v/sToken contributed to the reward.

This means we now have one single position for all Aave rewards instead of one per a/v/sToken (per network).

See also this Slack [thread](https://valora-app.slack.com/archives/C04NFRMSZQX/p1724715936061539).

| Before | After |
|-|-|
| ![image](https://github.com/user-attachments/assets/d3390f5d-e760-46d1-b56e-9d4113429f77) | ![image](https://github.com/user-attachments/assets/09ae899b-275a-496e-b63e-a6e52bf4cbed) |