### PR TITLE
fix(earn): Add some stuff to dataProps

### DIFF
--- a/src/apps/aave/positions.ts
+++ b/src/apps/aave/positions.ts
@@ -190,6 +190,7 @@ const hook: PositionsHook = {
               dataProps: {
                 manageUrl,
                 termsUrl: AAVE_TERMS_URL,
+                cantSeparateCompoundedInterest: true,
                 contractCreatedAt:
                   AAVE_CONTRACT_CREATED_AT[
                     getTokenId({

--- a/src/types/positions.ts
+++ b/src/types/positions.ts
@@ -78,13 +78,14 @@ export interface EarningItem {
   amount: DecimalNumber
   label: string
   tokenId: string
-  subtractFromDeposit?: boolean
+  includedInPoolBalance?: boolean
 }
 
 export interface EarnDataProps {
   contractCreatedAt?: string // ISO string
   manageUrl?: string
   termsUrl?: string
+  cantSeparateCompoundedInterest?: boolean
   tvl?: SerializedDecimalNumber
   yieldRates: YieldRate[]
   earningItems: EarningItem[]


### PR DESCRIPTION
Update `subtractFromDeposit` to be `includedInPoolBalance` to be more clear.

Add `cantSeparateCompoundedInterest` to make it possible to match designs for deposit card in wallet.