### PR TITLE
fix(beefy): add fallbackPriceUsd to CLM positions

### DIFF
--- a/src/apps/beefy/api.ts
+++ b/src/apps/beefy/api.ts
@@ -82,8 +82,12 @@ export async function getBeefyPrices(
   networkId: NetworkId,
 ): Promise<Record<string, number | undefined>> {
   const [lpsPrices, tokenPrices, tokens] = await Promise.all([
-    got.get(`https://api.beefy.finance/lps`).json<Record<string, number | undefined>>(),
-    got.get(`https://api.beefy.finance/prices`).json<Record<string, number | undefined>>(),
+    got
+      .get(`https://api.beefy.finance/lps`)
+      .json<Record<string, number | undefined>>(),
+    got
+      .get(`https://api.beefy.finance/prices`)
+      .json<Record<string, number | undefined>>(),
     got
       .get(
         `https://api.beefy.finance/tokens/${NETWORK_ID_TO_BEEFY_BLOCKCHAIN_ID[networkId]}`,

--- a/src/apps/beefy/positions.ts
+++ b/src/apps/beefy/positions.ts
@@ -196,7 +196,6 @@ const beefyBaseVaultsPositions = async (
         ? beefyConcentratedContractDefinition(
             networkId,
             vault,
-
             info.find(
               (i) =>
                 i.token0 === vault.depositTokenAddresses[0] &&
@@ -308,8 +307,10 @@ const hook: PositionsHook = {
       return []
     }
 
-    const { vaults, govVaults } = await getBeefyVaults(networkId)
-    const prices = await getBeefyPrices(networkId)
+    const [{ vaults, govVaults }, prices] = await Promise.all([
+      getBeefyVaults(networkId),
+      getBeefyPrices(networkId),
+    ])
 
     return [
       ...(await beefyBaseVaultsPositions(


### PR DESCRIPTION
This also adds fallbackPriceUsd for CLM positions.
So Beefy CLM positions don't miss part of the value.

| Before | After |
|-|-|
| ![IMG_7091](https://github.com/user-attachments/assets/dc0e0b1c-9cd6-4897-aea7-b359c981ca7d) | ![IMG_7092](https://github.com/user-attachments/assets/561af152-57dd-4ddc-8c2e-4c018db26e20) |

Before the change, because we don't have a $ price for MIGGLES, the MIGGLES-WETH position $ value was only showing the WETH part.
