### PR TITLE
chore(got): add hooks to capture timing info

### DIFF
--- a/src/utils/got.ts
+++ b/src/utils/got.ts
@@ -1,9 +1,47 @@
-import got, { ExtendOptions } from 'got'
+import got, { ExtendOptions, TimeoutError } from 'got'
+import { logger } from '../log'
 
 // https://github.com/sindresorhus/got/blob/HEAD/documentation/quick-start.md#options
 const options: ExtendOptions = {
   timeout: {
-    request: 10 * 1000,
+    request: 15 * 1000,
+  },
+  hooks: {
+    beforeError: [
+      (err) => {
+        if (err instanceof TimeoutError) {
+          logger.warn(
+            {
+              err,
+              request: {
+                url: err.request.requestUrl,
+                options: err.request.options,
+                timings: err.timings,
+              },
+            },
+            `Request timed out on ${err.request.options.method} ${err.request.requestUrl}`,
+          )
+        }
+        return err
+      },
+    ],
+    afterResponse: [
+      (response) => {
+        logger.debug(
+          {
+            response: {
+              statusCode: response.statusCode,
+              statusMessage: response.statusMessage,
+              url: response.request.requestUrl,
+              timings: response.timings,
+              method: response.request.options.method,
+            },
+          },
+          `Request completed with status ${response.statusCode}`,
+        )
+        return response
+      },
+    ],
   },
 }
 


### PR DESCRIPTION
- Increase timeout from 10 to 15s - noticed failures from getting swap quote or simulating transactions which sometimes take ~12s
- Add a `beforeError` hook that logs request details if there's a timeout - some timeout errors seem to be missing which request failed so this gives additional info
- Add an `afterResponse` hook that logs time taken by a request - helps debugging which api requests are slow.