### PR TITLE
chore(got): only log response timings if its greater than 5s

### DIFF
--- a/src/utils/got.ts
+++ b/src/utils/got.ts
@@ -27,18 +27,23 @@ const options: ExtendOptions = {
     ],
     afterResponse: [
       (response) => {
-        logger.info(
-          {
-            response: {
-              statusCode: response.statusCode,
-              statusMessage: response.statusMessage,
-              url: response.request.requestUrl,
-              timings: response.timings,
-              method: response.request.options.method,
+        if (
+          response.timings.phases.total &&
+          response.timings.phases.total > 5000
+        ) {
+          logger.info(
+            {
+              response: {
+                statusCode: response.statusCode,
+                statusMessage: response.statusMessage,
+                url: response.requestUrl,
+                timings: response.timings,
+                method: response.request.options.method,
+              },
             },
-          },
-          `Request completed with status ${response.statusCode}`,
-        )
+            `Request to ${response.request.options.method} ${response.requestUrl} took longer than 5s`,
+          )
+        }
         return response
       },
     ],

--- a/src/utils/got.ts
+++ b/src/utils/got.ts
@@ -1,6 +1,8 @@
 import got, { ExtendOptions, TimeoutError } from 'got'
 import { logger } from '../log'
 
+const gotLogger = logger.child({ module: 'got', level: 'debug' })
+
 // https://github.com/sindresorhus/got/blob/HEAD/documentation/quick-start.md#options
 const options: ExtendOptions = {
   timeout: {
@@ -10,7 +12,7 @@ const options: ExtendOptions = {
     beforeError: [
       (err) => {
         if (err instanceof TimeoutError) {
-          logger.warn(
+          gotLogger.warn(
             {
               err,
               request: {
@@ -31,7 +33,7 @@ const options: ExtendOptions = {
           response.timings.phases.total &&
           response.timings.phases.total > 5000
         ) {
-          logger.info(
+          gotLogger.debug(
             {
               response: {
                 statusCode: response.statusCode,

--- a/src/utils/got.ts
+++ b/src/utils/got.ts
@@ -31,7 +31,7 @@ const options: ExtendOptions = {
       (response) => {
         if (
           response.timings.phases.total &&
-          response.timings.phases.total > 5000
+          response.timings.phases.total > 5 * 1000
         ) {
           gotLogger.debug(
             {


### PR DESCRIPTION
The 5s is a bit arbitrary but from the logs, most requests take a max of 2-3 seconds, so adding this to capture the really slow ones and reduce noise in the logs. Also use debug child logger