### PR TITLE
ci: set concurrency to 80

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     "getShortcuts": "ts-node ./scripts/getShortcuts.ts",
     "triggerShortcut": "ts-node ./scripts/triggerShortcut.ts",
     "start": "ts-node ./scripts/start.ts",
-    "deploy:staging": "gcloud beta functions deploy --gen2 --project=celo-mobile-alfajores --region=us-central1 --runtime=nodejs20 --env-vars-file=src/api/staging.yaml --update-labels \"valora-repo=hooks,commit-sha=$(git rev-parse HEAD)\"",
+    "deploy:staging": "gcloud beta functions deploy --gen2 --concurrency=80 --project=celo-mobile-alfajores --region=us-central1 --runtime=nodejs20 --env-vars-file=src/api/staging.yaml --update-labels \"valora-repo=hooks,commit-sha=$(git rev-parse HEAD)\"",
     "deploy:staging:http": "yarn deploy:staging --trigger-http --allow-unauthenticated",
-    "deploy:production": "gcloud beta functions deploy --gen2 --memory=512MB --project=celo-mobile-mainnet --region=us-central1 --runtime=nodejs20 --env-vars-file=src/api/production.yaml --update-labels \"valora-repo=hooks,commit-sha=$(git rev-parse HEAD)\" --set-secrets=NETWORK_ID_TO_RPC_URL=hooks-rpc-urls:latest",
+    "deploy:production": "gcloud beta functions deploy --gen2 --concurrency=80 --memory=512MB --project=celo-mobile-mainnet --region=us-central1 --runtime=nodejs20 --env-vars-file=src/api/production.yaml --update-labels \"valora-repo=hooks,commit-sha=$(git rev-parse HEAD)\" --set-secrets=NETWORK_ID_TO_RPC_URL=hooks-rpc-urls:latest",
     "deploy:production:http": "yarn deploy:production --trigger-http --allow-unauthenticated"
   },
   "dependencies": {


### PR DESCRIPTION
The default concurrency for gen2 Cloud Functions is 1.
Which caused us to hit the max instances limit of 100 when we got more traffic.

I chose 80 as it's the [default recommendation](https://cloud.google.com/run/docs/about-concurrency#maximum_concurrent_requests_per_instance) for Cloud Run. We may need to tweak it.

See Slack [thread](https://valora-app.slack.com/archives/C02N3AR2P2S/p1727207104465159?thread_ts=1727204349.338389&cid=C02N3AR2P2S).