### PR TITLE
fix(beefy): try catch on userVaults map callback

### DIFF
--- a/src/apps/beefy/positions.ts
+++ b/src/apps/beefy/positions.ts
@@ -191,21 +191,26 @@ const beefyBaseVaultsPositions = async (
           args: [address, clmVaults.map((vault) => vault.earnContractAddress)],
         })
   return userVaults
-    .map((vault) =>
-      vault.type === 'cowcentrated'
-        ? beefyConcentratedContractDefinition(
-            networkId,
-            vault,
-            info.find(
-              (i) =>
-                i.token0 === vault.depositTokenAddresses[0] &&
-                i.token1 === vault.depositTokenAddresses[1],
-            ),
-            'CLM Vault',
-            prices,
-          )
-        : beefyAppTokenDefinition(networkId, vault, prices),
-    )
+    .map((vault) => {
+      try {
+        return vault.type === 'cowcentrated'
+          ? beefyConcentratedContractDefinition(
+              networkId,
+              vault,
+              info.find(
+                (i) =>
+                  i.token0 === vault.depositTokenAddresses[0] &&
+                  i.token1 === vault.depositTokenAddresses[1],
+              ),
+              'CLM Vault',
+              prices,
+            )
+          : beefyAppTokenDefinition(networkId, vault, prices)
+      } catch (error) {
+        logger.error('Error processing vault', vault, error)
+        return null
+      }
+    })
     .filter((position): position is ContractPositionDefinition => !!position)
 }
 


### PR DESCRIPTION
### Description

An error was being thrown in [here](https://github.com/valora-inc/hooks/blob/main/src/apps/beefy/positions.ts#L55), so I've wrapped the map callback with a try-catch to prevent other pools from not being returned when the error throws.

### Related Issues
Part of ACT-1375