### PR TITLE
chore(earn): Remove SwapDeposit simulateTransaction call that always fails

### DIFF
--- a/src/apps/aave/shortcuts.ts
+++ b/src/apps/aave/shortcuts.ts
@@ -261,7 +261,6 @@ const hook: ShortcutsHook = {
             swapFromToken,
             swapToTokenAddress: tokenAddress,
             walletAddress,
-            simulatedGasPadding: [0n, SIMULATED_DEPOSIT_GAS_PADDING],
             enableAppFee,
             // based off of https://docs.squidrouter.com/building-with-squid-v2/key-concepts/hooks/build-a-posthook
             postHook: {

--- a/src/apps/allbridge/shortcuts.ts
+++ b/src/apps/allbridge/shortcuts.ts
@@ -225,7 +225,6 @@ const hook: ShortcutsHook = {
             swapFromToken,
             swapToTokenAddress: tokenAddress,
             walletAddress,
-            simulatedGasPadding: [0n, SIMULATED_DEPOSIT_GAS_PADDING],
             enableAppFee,
             // based off of https://docs.squidrouter.com/building-with-squid-v2/key-concepts/hooks/build-a-posthook
             postHook: {

--- a/src/utils/prepareSwapTransactions.test.ts
+++ b/src/utils/prepareSwapTransactions.test.ts
@@ -1,7 +1,6 @@
 import { ChainType, SquidCallType } from '@0xsquid/squid-types'
 import { NetworkId } from '../types/networkId'
 import { prepareSwapTransactions } from './prepareSwapTransactions'
-import { simulateTransactions } from '../runtime/simulateTransactions'
 import got from './got'
 import { Address } from 'viem'
 
@@ -79,7 +78,7 @@ describe('prepareSwapTransactions', () => {
     mockReadContract.mockResolvedValue(0)
   })
 
-  it('simulates post hook transactions and prepares swap transaction from native token', async () => {
+  it('prepares swap transaction from native token', async () => {
     const { transactions, dataProps } = await prepareSwapTransactions({
       networkId: NetworkId['arbitrum-one'],
       walletAddress: '0x2b8441ef13333ffa955c9ea5ab5b3692da95260d',
@@ -131,7 +130,7 @@ describe('prepareSwapTransactions', () => {
     )
   })
 
-  it('simulates post hook transactions and prepares swap transaction from erc20 token', async () => {
+  it('prepares swap transaction from erc20 token', async () => {
     const { transactions, dataProps } = await prepareSwapTransactions({
       networkId: NetworkId['arbitrum-one'],
       walletAddress: '0x2b8441ef13333ffa955c9ea5ab5b3692da95260d',
@@ -212,10 +211,7 @@ describe('prepareSwapTransactions', () => {
     })
   })
 
-  it('uses default gas for postHook if simulation fails', async () => {
-    jest
-      .mocked(simulateTransactions)
-      .mockRejectedValue(new Error('Failed to simulate'))
+  it('uses default gas for postHook', async () => {
     const { transactions } = await prepareSwapTransactions({
       networkId: NetworkId['arbitrum-one'],
       walletAddress: '0x2b8441ef13333ffa955c9ea5ab5b3692da95260d',

--- a/src/utils/prepareSwapTransactions.test.ts
+++ b/src/utils/prepareSwapTransactions.test.ts
@@ -14,7 +14,6 @@ jest.mock('./got', () => ({
     json: mockGotPostJson,
   })),
 }))
-jest.mock('../runtime/simulateTransactions')
 jest.mock('../runtime/client', () => ({
   getClient: jest.fn(() => ({
     readContract: mockReadContract,
@@ -74,15 +73,6 @@ const swapTransaction = {
 describe('prepareSwapTransactions', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    jest.mocked(simulateTransactions).mockResolvedValue(
-      [995, 2134].map((gas) => ({
-        status: 'success',
-        blockNumber: '1',
-        gasNeeded: gas,
-        gasUsed: gas,
-        gasPrice: '1',
-      })),
-    )
     mockGotPostJson.mockResolvedValue({
       unvalidatedSwapTransaction: swapTransaction,
     })
@@ -127,11 +117,11 @@ describe('prepareSwapTransactions', () => {
             calls: [
               {
                 ...mockPostHook.calls[0],
-                estimatedGas: '996',
+                estimatedGas: '1000',
               },
               {
                 ...mockPostHook.calls[1],
-                estimatedGas: '2234',
+                estimatedGas: '2000',
               },
             ],
           },
@@ -185,11 +175,11 @@ describe('prepareSwapTransactions', () => {
             calls: [
               {
                 ...mockPostHook.calls[0],
-                estimatedGas: '995',
+                estimatedGas: '1000',
               },
               {
                 ...mockPostHook.calls[1],
-                estimatedGas: '2134',
+                estimatedGas: '2000',
               },
             ],
           },

--- a/src/utils/prepareSwapTransactions.ts
+++ b/src/utils/prepareSwapTransactions.ts
@@ -7,10 +7,6 @@ import {
 import { EvmContractCall, Hook as SquidHook } from '@0xsquid/squid-types'
 import { NetworkId } from '../types/networkId'
 import { Address, encodeFunctionData, erc20Abi, parseUnits } from 'viem'
-import {
-  simulateTransactions,
-  UnsupportedSimulateRequest,
-} from '../runtime/simulateTransactions'
 import { logger } from '../log'
 import { getConfig } from '../config'
 import got from './got'
@@ -38,7 +34,6 @@ export async function prepareSwapTransactions({
   swapToTokenAddress,
   networkId,
   walletAddress,
-  simulatedGasPadding,
   enableAppFee,
 }: {
   swapFromToken: z.infer<typeof tokenAmountWithMetadata>
@@ -52,38 +47,6 @@ export async function prepareSwapTransactions({
   simulatedGasPadding?: bigint[]
   enableAppFee?: boolean
 }): Promise<TriggerOutputShape<'swap-deposit'>> {
-  let postHookWithSimulatedGas = postHook
-
-  try {
-    const simulatedTransactions = await simulateTransactions({
-      networkId,
-      transactions: postHook.calls.map((call) => ({
-        networkId,
-        from: walletAddress,
-        to: call.target,
-        data: call.callData,
-      })),
-    })
-
-    postHookWithSimulatedGas = {
-      ...postHook,
-      calls: postHook.calls.map((call, index) => {
-        return {
-          ...call,
-          estimatedGas: (
-            BigInt(simulatedTransactions[index].gasNeeded) +
-            (simulatedGasPadding?.[index] ?? 0n)
-          ).toString(),
-        }
-      }),
-    }
-  } catch (error) {
-    if (!(error instanceof UnsupportedSimulateRequest)) {
-      logger.warn(error, 'Unexpected error during simulateTransactions')
-    }
-    // use default already set in the postHook, no changes needed
-  }
-
   const amountToSwap = parseUnits(swapFromToken.amount, swapFromToken.decimals)
 
   const swapParams = {
@@ -95,7 +58,7 @@ export async function prepareSwapTransactions({
     sellNetworkId: networkId,
     sellAmount: amountToSwap.toString(),
     slippagePercentage: '1',
-    postHook: postHookWithSimulatedGas,
+    postHook,
     userAddress: walletAddress,
     enableAppFee,
   }


### PR DESCRIPTION
Fails because user wallet doesn't have necessary tokens. No functional change by removing, just saves an API call.