### PR TITLE
feat(earn): Add supportedPools query param to getEarnPositions

### DIFF
--- a/src/api/index.test.ts
+++ b/src/api/index.test.ts
@@ -321,7 +321,7 @@ describe('GET /getPositions', () => {
 })
 
 describe('GET /getEarnPositions', () => {
-  it('returns default earn positions for arbitrum when supportedPools not passed in', async () => {
+  it('returns default earn positions for arbitrum when supportedPools and supportedAppIds not passed in', async () => {
     const server = getTestServer('hooks-api')
     const response = await request(server)
       .get('/getEarnPositions')
@@ -335,7 +335,7 @@ describe('GET /getEarnPositions', () => {
       data: TEST_POSITIONS_ARBITRUM,
     })
   })
-  it('returns expected earn positions for arbitrum when supportedPools is passed in', async () => {
+  it('returns expected earn positions for arbitrum when supportedPools and supportedAppIds are passed in', async () => {
     const server = getTestServer('hooks-api')
     const response = await request(server)
       .get('/getEarnPositions')
@@ -344,6 +344,7 @@ describe('GET /getEarnPositions', () => {
         supportedPools: [
           'arbitrum-one:0x724dc807b04555b71ed48a6896b6f41593b8c637',
         ],
+        supportedAppIds: ['allbridge', 'aave'],
         address: WALLET_ADDRESS,
       })
       .expect(200)
@@ -352,7 +353,7 @@ describe('GET /getEarnPositions', () => {
       data: TEST_POSITIONS_ARBITRUM,
     })
   })
-  it('returns default earn positions for celo when supportedPools not passed in', async () => {
+  it('returns default earn positions for celo when supportedPools and supportedAppIds not passed in', async () => {
     jest.mocked(getPositions).mockResolvedValue(TEST_POSITIONS_CELO_EARN)
     const server = getTestServer('hooks-api')
     const response = await request(server)
@@ -367,7 +368,7 @@ describe('GET /getEarnPositions', () => {
       data: TEST_POSITIONS_CELO_EARN,
     })
   })
-  it('returns expected earn positions for celo when supportedPools is passed in', async () => {
+  it('returns expected earn positions for celo when supportedPools and supportedAppIds are passed in', async () => {
     const server = getTestServer('hooks-api')
     const response = await request(server)
       .get('/getEarnPositions')
@@ -376,6 +377,7 @@ describe('GET /getEarnPositions', () => {
         supportedPools: [
           `${NetworkId['celo-mainnet']}:0xfb2c7c10e731ebe96dabdf4a96d656bfe8e2b5af`,
         ],
+        supportedAppIds: ['allbridge', 'aave'],
         address: WALLET_ADDRESS,
       })
       .expect(200)
@@ -384,7 +386,7 @@ describe('GET /getEarnPositions', () => {
       data: TEST_POSITIONS_CELO_EARN,
     })
   })
-  it('ignores bad values in supportedPools', async () => {
+  it('does not return pool if ID not in supportedPools', async () => {
     const server = getTestServer('hooks-api')
     const response = await request(server)
       .get('/getEarnPositions')

--- a/src/api/index.test.ts
+++ b/src/api/index.test.ts
@@ -386,14 +386,14 @@ it('returns expected earn positions for celo when supportedPools is passed in', 
     data: TEST_POSITIONS_CELO_EARN,
   })
 })
-it('returns no earn positions for celo when supportedPools is empty', async () => {
+it('ignores bad values in supportedPools', async () => {
   jest.mocked(getPositions).mockResolvedValue(TEST_POSITIONS_CELO_EARN)
   const server = getTestServer('hooks-api')
   const response = await request(server)
     .get('/getEarnPositions')
     .query({
       networkIds: [NetworkId['celo-mainnet']],
-      supportedPools: [],
+      supportedPools: ['0xbadAddress'],
       address: WALLET_ADDRESS,
     })
     .expect(200)

--- a/src/api/index.test.ts
+++ b/src/api/index.test.ts
@@ -321,7 +321,7 @@ describe('GET /getPositions', () => {
 })
 
 describe('GET /getEarnPositions', () => {
-  it('returns earn positions for arbitrum', async () => {
+  it('returns default earn positions for arbitrum when supportedPools not passed in', async () => {
     const server = getTestServer('hooks-api')
     const response = await request(server)
       .get('/getEarnPositions')
@@ -335,7 +335,7 @@ describe('GET /getEarnPositions', () => {
       data: TEST_POSITIONS_ARBITRUM,
     })
   })
-  it('returns earn positions for celo', async () => {
+  it('returns default earn positions for celo when supportedPools not passed in', async () => {
     jest.mocked(getPositions).mockResolvedValue(TEST_POSITIONS_CELO_EARN)
     const server = getTestServer('hooks-api')
     const response = await request(server)
@@ -349,6 +349,53 @@ describe('GET /getEarnPositions', () => {
       message: 'OK',
       data: TEST_POSITIONS_CELO_EARN,
     })
+  })
+})
+it('returns expected earn positions for arbitrum when supportedPools is passed in', async () => {
+  const server = getTestServer('hooks-api')
+  const response = await request(server)
+    .get('/getEarnPositions')
+    .query({
+      networkIds: [NetworkId['arbitrum-one']],
+      supportedPools:[`${NetworkId['arbitrum-one']}:0x724dc807b04555b71ed48a6896b6f41593b8c637`],
+      address: WALLET_ADDRESS,
+    })
+    .expect(200)
+  expect(response.body).toEqual({
+    message: 'OK',
+    data: TEST_POSITIONS_ARBITRUM,
+  })
+})
+it('returns expected earn positions for celo when supportedPools is passed in', async () => {
+  jest.mocked(getPositions).mockResolvedValue(TEST_POSITIONS_CELO_EARN)
+  const server = getTestServer('hooks-api')
+  const response = await request(server)
+    .get('/getEarnPositions')
+    .query({
+      networkIds: [NetworkId['celo-mainnet']],
+      supportedPools: [`${NetworkId['celo-mainnet']}:0xfb2c7c10e731ebe96dabdf4a96d656bfe8e2b5af`],
+      address: WALLET_ADDRESS,
+    })
+    .expect(200)
+  expect(response.body).toEqual({
+    message: 'OK',
+    data: TEST_POSITIONS_CELO_EARN,
+  })
+})
+it('returns no earn positions for celo when supportedPools is empty', async () => {
+  jest.mocked(getPositions).mockResolvedValue(TEST_POSITIONS_CELO_EARN)
+  const server = getTestServer('hooks-api')
+  const response = await request(server)
+    .get('/getEarnPositions')
+    .query({
+      networkIds: [NetworkId['celo-mainnet']],
+      supportedPools: [],
+      address: WALLET_ADDRESS,
+    })
+    .expect(200)
+  expect(response.body).toEqual({
+    message: 'OK',
+    data: [],
   })
 })
 

--- a/src/api/index.test.ts
+++ b/src/api/index.test.ts
@@ -357,7 +357,9 @@ it('returns expected earn positions for arbitrum when supportedPools is passed i
     .get('/getEarnPositions')
     .query({
       networkIds: [NetworkId['arbitrum-one']],
-      supportedPools:[`${NetworkId['arbitrum-one']}:0x724dc807b04555b71ed48a6896b6f41593b8c637`],
+      supportedPools: [
+        `${NetworkId['arbitrum-one']}:0x724dc807b04555b71ed48a6896b6f41593b8c637`,
+      ],
       address: WALLET_ADDRESS,
     })
     .expect(200)
@@ -373,7 +375,9 @@ it('returns expected earn positions for celo when supportedPools is passed in', 
     .get('/getEarnPositions')
     .query({
       networkIds: [NetworkId['celo-mainnet']],
-      supportedPools: [`${NetworkId['celo-mainnet']}:0xfb2c7c10e731ebe96dabdf4a96d656bfe8e2b5af`],
+      supportedPools: [
+        `${NetworkId['celo-mainnet']}:0xfb2c7c10e731ebe96dabdf4a96d656bfe8e2b5af`,
+      ],
       address: WALLET_ADDRESS,
     })
     .expect(200)

--- a/src/api/index.test.ts
+++ b/src/api/index.test.ts
@@ -335,6 +335,23 @@ describe('GET /getEarnPositions', () => {
       data: TEST_POSITIONS_ARBITRUM,
     })
   })
+  it('returns expected earn positions for arbitrum when supportedPools is passed in', async () => {
+    const server = getTestServer('hooks-api')
+    const response = await request(server)
+      .get('/getEarnPositions')
+      .query({
+        networkIds: [NetworkId['arbitrum-one']],
+        supportedPools: [
+          'arbitrum-one:0x724dc807b04555b71ed48a6896b6f41593b8c637',
+        ],
+        address: WALLET_ADDRESS,
+      })
+      .expect(200)
+    expect(response.body).toEqual({
+      message: 'OK',
+      data: TEST_POSITIONS_ARBITRUM,
+    })
+  })
   it('returns default earn positions for celo when supportedPools not passed in', async () => {
     jest.mocked(getPositions).mockResolvedValue(TEST_POSITIONS_CELO_EARN)
     const server = getTestServer('hooks-api')
@@ -350,56 +367,37 @@ describe('GET /getEarnPositions', () => {
       data: TEST_POSITIONS_CELO_EARN,
     })
   })
-})
-it('returns expected earn positions for arbitrum when supportedPools is passed in', async () => {
-  const server = getTestServer('hooks-api')
-  const response = await request(server)
-    .get('/getEarnPositions')
-    .query({
-      networkIds: [NetworkId['arbitrum-one']],
-      supportedPools: [
-        `${NetworkId['arbitrum-one']}:0x724dc807b04555b71ed48a6896b6f41593b8c637`,
-      ],
-      address: WALLET_ADDRESS,
+  it('returns expected earn positions for celo when supportedPools is passed in', async () => {
+    const server = getTestServer('hooks-api')
+    const response = await request(server)
+      .get('/getEarnPositions')
+      .query({
+        networkIds: [NetworkId['celo-mainnet']],
+        supportedPools: [
+          `${NetworkId['celo-mainnet']}:0xfb2c7c10e731ebe96dabdf4a96d656bfe8e2b5af`,
+        ],
+        address: WALLET_ADDRESS,
+      })
+      .expect(200)
+    expect(response.body).toEqual({
+      message: 'OK',
+      data: TEST_POSITIONS_CELO_EARN,
     })
-    .expect(200)
-  expect(response.body).toEqual({
-    message: 'OK',
-    data: TEST_POSITIONS_ARBITRUM,
   })
-})
-it('returns expected earn positions for celo when supportedPools is passed in', async () => {
-  jest.mocked(getPositions).mockResolvedValue(TEST_POSITIONS_CELO_EARN)
-  const server = getTestServer('hooks-api')
-  const response = await request(server)
-    .get('/getEarnPositions')
-    .query({
-      networkIds: [NetworkId['celo-mainnet']],
-      supportedPools: [
-        `${NetworkId['celo-mainnet']}:0xfb2c7c10e731ebe96dabdf4a96d656bfe8e2b5af`,
-      ],
-      address: WALLET_ADDRESS,
+  it('ignores bad values in supportedPools', async () => {
+    const server = getTestServer('hooks-api')
+    const response = await request(server)
+      .get('/getEarnPositions')
+      .query({
+        networkIds: [NetworkId['celo-mainnet']],
+        supportedPools: ['0xbadAddress'],
+        address: WALLET_ADDRESS,
+      })
+      .expect(200)
+    expect(response.body).toEqual({
+      message: 'OK',
+      data: [],
     })
-    .expect(200)
-  expect(response.body).toEqual({
-    message: 'OK',
-    data: TEST_POSITIONS_CELO_EARN,
-  })
-})
-it('ignores bad values in supportedPools', async () => {
-  jest.mocked(getPositions).mockResolvedValue(TEST_POSITIONS_CELO_EARN)
-  const server = getTestServer('hooks-api')
-  const response = await request(server)
-    .get('/getEarnPositions')
-    .query({
-      networkIds: [NetworkId['celo-mainnet']],
-      supportedPools: ['0xbadAddress'],
-      address: WALLET_ADDRESS,
-    })
-    .expect(200)
-  expect(response.body).toEqual({
-    message: 'OK',
-    data: [],
   })
 })
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -166,11 +166,9 @@ function createApp() {
         .nonempty()
         .or(z.nativeEnum(NetworkId)), // singleton arrays sometimes serialize as single values
       supportedPools: z
-        .array(
-          z
-            .string()
-            .transform((val) => val.toLowerCase()),
-        )
+        .array(z.string())
+        .nonempty()
+        .or(z.string()) // singleton arrays sometimes serialize as single values
         .optional(),
     }),
   })
@@ -186,9 +184,13 @@ function createApp() {
       const networkIds = getNetworkIds(parsedRequest.query).filter(
         (networkId) => config.EARN_SUPPORTED_NETWORK_IDS.includes(networkId),
       )
-      const supportedPools =
-        new Set(parsedRequest.query.supportedPools) ??
-        LEGACY_EARN_SUPPORTED_POSITION_IDS
+      const supportedPools = parsedRequest.query.supportedPools
+        ? new Set(
+            Array.isArray(parsedRequest.query.supportedPools)
+              ? parsedRequest.query.supportedPools
+              : [parsedRequest.query.supportedPools],
+          )
+        : LEGACY_EARN_SUPPORTED_POSITION_IDS
 
       const positions = (
         await Promise.all(

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -187,7 +187,9 @@ function createApp() {
       const networkIds = getNetworkIds(parsedRequest.query).filter(
         (networkId) => config.EARN_SUPPORTED_NETWORK_IDS.includes(networkId),
       )
-      const supportedPools = new Set(parsedRequest.query.supportedPools) ?? LEGACY_EARN_SUPPORTED_POSITION_IDS
+      const supportedPools =
+        new Set(parsedRequest.query.supportedPools) ??
+        LEGACY_EARN_SUPPORTED_POSITION_IDS
 
       const positions = (
         await Promise.all(

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -169,7 +169,6 @@ function createApp() {
         .array(
           z
             .string()
-            .regex(/^0x[a-fA-F0-9]{40}$/)
             .transform((val) => val.toLowerCase()),
         )
         .optional(),

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -22,8 +22,8 @@ import {
 import { Transaction } from '../types/shortcuts'
 import { parseRequest } from './parseRequest'
 
-const EARN_SUPPORTED_APP_IDS = ['aave', 'allbridge']
-const LEGACY_EARN_SUPPORTED_POSITION_IDS = new Set([
+const DEFAULT_EARN_SUPPORTED_APP_IDS = ['aave', 'allbridge']
+const DEFAULT_EARN_SUPPORTED_POSITION_IDS = new Set([
   // Aave USDC
   `${NetworkId['arbitrum-one']}:0x724dc807b04555b71ed48a6896b6f41593b8c637`,
   `${NetworkId['arbitrum-sepolia']}:0x460b97bd498e1157530aeb3086301d5225b91216`,
@@ -170,6 +170,11 @@ function createApp() {
         .nonempty()
         .or(z.string()) // singleton arrays sometimes serialize as single values
         .optional(),
+      supportedAppIds: z
+        .array(z.string())
+        .nonempty()
+        .or(z.string()) // singleton arrays sometimes serialize as single values
+        .optional(),
     }),
   })
 
@@ -190,7 +195,12 @@ function createApp() {
               ? parsedRequest.query.supportedPools
               : [parsedRequest.query.supportedPools],
           )
-        : LEGACY_EARN_SUPPORTED_POSITION_IDS
+        : DEFAULT_EARN_SUPPORTED_POSITION_IDS
+      const supportedAppIds = parsedRequest.query.supportedAppIds
+        ? Array.isArray(parsedRequest.query.supportedAppIds)
+          ? parsedRequest.query.supportedAppIds
+          : [parsedRequest.query.supportedAppIds]
+        : DEFAULT_EARN_SUPPORTED_APP_IDS
 
       const positions = (
         await Promise.all(
@@ -199,7 +209,7 @@ function createApp() {
               networkId,
               // Earn positions are not user-specific
               address: undefined,
-              appIds: EARN_SUPPORTED_APP_IDS,
+              appIds: supportedAppIds,
               t: req.t,
             }),
           ),


### PR DESCRIPTION
If query param not provided, default to legacy hardcoded list.

Unit tests updated/added.