### PR TITLE
feat: add manageUrl to displayProps

### DIFF
--- a/src/apps/beefy/positions.ts
+++ b/src/apps/beefy/positions.ts
@@ -93,6 +93,7 @@ const beefyAppTokenDefinition = ({
         description: 'Vault',
         imageUrl:
           'https://raw.githubusercontent.com/valora-inc/dapp-list/main/assets/beefy.png',
+        manageUrl: BEEFY_VAULT_BASE_URL + vault.id,
       }
     },
     pricePerShare: async ({ tokensByTokenId }) => {

--- a/src/apps/compound/positions.ts
+++ b/src/apps/compound/positions.ts
@@ -152,7 +152,9 @@ const hook: PositionsHook = {
                 description: `${baseTokenDescription.symbol} Market`,
                 imageUrl:
                   'https://raw.githubusercontent.com/valora-inc/hooks/main/src/apps/compound/assets/compound.png',
-                manageUrl: `https://app.compound.finance/markets/${baseTokenDescription.symbol}-${COMPOUND_NETWORK_NAME[networkId]}`,
+                manageUrl: COMPOUND_NETWORK_NAME[networkId]
+                  ? `https://app.compound.finance/markets/${baseTokenDescription.symbol}-${COMPOUND_NETWORK_NAME[networkId]}`
+                  : undefined,
               }
             },
             balances: async ({ resolvedTokensByTokenId }) => {

--- a/src/apps/compound/positions.ts
+++ b/src/apps/compound/positions.ts
@@ -14,6 +14,14 @@ import {
   compoundMulticallBytecode,
 } from './abis/compound-multicall'
 
+const COMPOUND_NETWORK_NAME: Partial<Record<NetworkId, string>> = {
+  [NetworkId['ethereum-mainnet']]: 'mainnet',
+  [NetworkId['op-mainnet']]: 'op',
+  [NetworkId['polygon-pos-mainnet']]: 'polygon',
+  [NetworkId['base-mainnet']]: 'basemainnet',
+  [NetworkId['arbitrum-one']]: 'arb',
+}
+
 // Data from https://docs.compound.finance/
 const MARKETS: { networkId: NetworkId; address: Address }[] = [
   {
@@ -144,6 +152,7 @@ const hook: PositionsHook = {
                 description: `${baseTokenDescription.symbol} Market`,
                 imageUrl:
                   'https://raw.githubusercontent.com/valora-inc/hooks/main/src/apps/compound/assets/compound.png',
+                manageUrl: `https://app.compound.finance/markets/${baseTokenDescription.symbol}-${COMPOUND_NETWORK_NAME[networkId]}`,
               }
             },
             balances: async ({ resolvedTokensByTokenId }) => {

--- a/src/apps/curve/positions.ts
+++ b/src/apps/curve/positions.ts
@@ -37,6 +37,11 @@ interface CurveApiResponse {
         symbol: symbol
         isBasePoolLpToken: boolean
       }[]
+      poolUrls: {
+        swap: string[]
+        deposit: string[]
+        withdraw: string[]
+      }
       usdTotal: number
     }[]
   }
@@ -149,6 +154,7 @@ async function getPoolPositionDefinition(
         description: 'Pool',
         imageUrl:
           'https://raw.githubusercontent.com/valora-inc/dapp-list/main/assets/curve.png',
+        manageUrl: pool.poolUrls.withdraw[0],
       }
     },
     pricePerShare: async ({ tokensByTokenId }) => {

--- a/src/apps/example/positions.ts
+++ b/src/apps/example/positions.ts
@@ -75,6 +75,8 @@ const hook: PositionsHook = {
           title: 'Example position',
           description: 'See the code!',
           imageUrl: DEFAULT_IMG_URL,
+          // This optional param should point to a url where the user can view and/or manage the position
+          manageUrl: 'https://example.com/?pool-id',
         },
       },
     ]

--- a/src/apps/uniswap/positions.ts
+++ b/src/apps/uniswap/positions.ts
@@ -59,6 +59,15 @@ const UNI_V3_ADDRESSES_BY_NETWORK_ID: {
   [NetworkId['base-sepolia']]: undefined,
 }
 
+const UNISWAP_NETWORK_NAME: Partial<Record<NetworkId, string>> = {
+  [NetworkId['ethereum-mainnet']]: 'ethereum',
+  [NetworkId['op-mainnet']]: 'optimism',
+  [NetworkId['polygon-pos-mainnet']]: 'polygon',
+  [NetworkId['base-mainnet']]: 'base',
+  [NetworkId['arbitrum-one']]: 'arbitrum',
+  [NetworkId['celo-mainnet']]: 'celo',
+}
+
 export async function getUniswapV3PositionDefinitions(
   networkId: NetworkId,
   address: Address,
@@ -110,6 +119,9 @@ export async function getUniswapV3PositionDefinitions(
           }`,
           description: 'Pool',
           imageUrl,
+          manageUrl: UNISWAP_NETWORK_NAME[networkId]
+            ? `https://app.uniswap.org/explore/pools/${UNISWAP_NETWORK_NAME[networkId]}/${pool.poolAddress}`
+            : undefined,
         }),
         balances: async ({ resolvedTokensByTokenId }) => {
           const token0Decimals =

--- a/src/types/positions.ts
+++ b/src/types/positions.ts
@@ -58,6 +58,7 @@ export interface DisplayProps {
   title: string // Example: CELO / cUSD
   description: string // Example: Pool
   imageUrl: string // Example: https://...
+  manageUrl?: string // Example: https://<PoolSpecificUrl>
 }
 
 export interface DataPropsContext {


### PR DESCRIPTION
### Description

- Adds an optional `manageUrl` to `displayprops` which can be specified per pool.
- `manageUrl` was added for the following apps:
  - Beefy
  - Compound
  - Curve
  - Uniswap
  - Example

### Related Issues
Part of ACT-1384