### PR TITLE
fix(aave): use latest aave from address book

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@0xsquid/squid-types": "^0.1.111",
+    "@bgd-labs/aave-address-book": "^3.7.0",
     "@google-cloud/functions-framework": "^3.4.2",
     "@valora/http-handler": "^0.0.1",
     "@valora/logging": "^1.3.18",

--- a/src/apps/aave/constants.ts
+++ b/src/apps/aave/constants.ts
@@ -1,8 +1,16 @@
 import { Address } from '../../types/address'
 import { NetworkId } from '../../types/networkId'
+import {
+  AaveV3Ethereum,
+  AaveV3Sepolia,
+  AaveV3Arbitrum,
+  AaveV3ArbitrumSepolia,
+  AaveV3Optimism,
+  AaveV3OptimismSepolia,
+  AaveV3Polygon,
+  AaveV3Base,
+} from '@bgd-labs/aave-address-book'
 
-// See https://github.com/bgd-labs/aave-address-book/tree/fbb590953db44d62a756d4639cb77ea58afb299c/src/ts
-// and https://docs.aave.com/developers/deployed-contracts/v3-mainnet
 export const AAVE_V3_ADDRESSES_BY_NETWORK_ID: Record<
   NetworkId,
   | {
@@ -17,69 +25,63 @@ export const AAVE_V3_ADDRESSES_BY_NETWORK_ID: Record<
   [NetworkId['celo-mainnet']]: undefined,
   [NetworkId['celo-alfajores']]: undefined,
   [NetworkId['ethereum-mainnet']]: {
-    poolAddressesProvider: '0x2f39d218133afab8f2b819b1066c7e434ad94e9e',
-    uiPoolDataProvider: '0x5c5228ac8bc1528482514af3e27e692495148717',
-    uiIncentiveDataProvider: '0x162a7ac02f547ad796ca549f757e2b8d1d9b10a6',
-    incentivesController: '0x8164cc65827dcfe994ab23944cbc90e0aa80bfcb',
-    pool: '0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2',
+    poolAddressesProvider: AaveV3Ethereum.POOL_ADDRESSES_PROVIDER,
+    uiPoolDataProvider: '0x194324C9Af7f56E22F1614dD82E18621cb9238E7', // todo: use AaveV3Ethereum.UI_POOL_DATA_PROVIDER when it is updated in the address book
+    uiIncentiveDataProvider: '0x5a40cDe2b76Da2beD545efB3ae15708eE56aAF9c', // todo: use AaveV3Ethereum.UI_INCENTIVE_DATA_PROVIDER when it is updated in the address book
+    incentivesController: AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER,
+    pool: AaveV3Ethereum.POOL,
   },
   [NetworkId['ethereum-sepolia']]: {
-    poolAddressesProvider: '0x012bac54348c0e635dcac9d5fb99f06f24136c9a',
-    uiPoolDataProvider: '0x69529987fa4a075d0c00b0128fa848dc9ebbe9ce',
-    uiIncentiveDataProvider: '0xba25de9a7dc623b30799f33b770d31b44c2c3b77',
-    incentivesController: '0x4da5c4da71c5a167171cc839487536d86e083483',
-    pool: '0x6ae43d3271ff6888e7fc43fd7321a503ff738951',
+    poolAddressesProvider: AaveV3Sepolia.POOL_ADDRESSES_PROVIDER,
+    uiPoolDataProvider: AaveV3Sepolia.UI_POOL_DATA_PROVIDER,
+    uiIncentiveDataProvider: AaveV3Sepolia.UI_INCENTIVE_DATA_PROVIDER,
+    incentivesController: AaveV3Sepolia.DEFAULT_INCENTIVES_CONTROLLER,
+    pool: AaveV3Sepolia.POOL,
   },
   [NetworkId['arbitrum-one']]: {
-    poolAddressesProvider: '0xa97684ead0e402dc232d5a977953df7ecbab3cdb',
-    uiPoolDataProvider: '0x145de30c929a065582da84cf96f88460db9745a7',
-    uiIncentiveDataProvider: '0xda67af3403555ce0ae3ffc22fdb7354458277358',
-    incentivesController: '0x929ec64c34a17401f460460d4b9390518e5b473e',
-    pool: '0x794a61358d6845594f94dc1db02a252b5b4814ad',
+    poolAddressesProvider: AaveV3Arbitrum.POOL_ADDRESSES_PROVIDER,
+    uiPoolDataProvider: '0xc0179321f0825c3e0F59Fe7Ca4E40557b97797a3', // todo: use AaveV3Arbitrum.UI_POOL_DATA_PROVIDER when it is updated in the address book
+    uiIncentiveDataProvider: '0xE92cd6164CE7DC68e740765BC1f2a091B6CBc3e4', // todo: use AaveV3Arbitrum.UI_INCENTIVE_DATA_PROVIDER when it is updated in the address book
+    incentivesController: AaveV3Arbitrum.DEFAULT_INCENTIVES_CONTROLLER,
+    pool: AaveV3Arbitrum.POOL,
   },
   [NetworkId['arbitrum-sepolia']]: {
-    poolAddressesProvider: '0xb25a5d144626a0d488e52ae717a051a2e9997076',
-    uiPoolDataProvider: '0x97cf44bf6a9a3d2b4f32b05c480dbedc018f72a9',
-    uiIncentiveDataProvider: '0xb90fa850a4af6d30fea8b41989eaaecdca8fd414',
-    incentivesController: '0x3a203b14cf8749a1e3b7314c6c49004b77ee667a',
-    pool: '0xbfc91d59fdaa134a4ed45f7b584caf96d7792eff',
+    poolAddressesProvider: AaveV3ArbitrumSepolia.POOL_ADDRESSES_PROVIDER,
+    uiPoolDataProvider: AaveV3ArbitrumSepolia.UI_POOL_DATA_PROVIDER,
+    uiIncentiveDataProvider: AaveV3ArbitrumSepolia.UI_INCENTIVE_DATA_PROVIDER,
+    incentivesController: AaveV3ArbitrumSepolia.DEFAULT_INCENTIVES_CONTROLLER,
+    pool: AaveV3ArbitrumSepolia.POOL,
   },
   [NetworkId['op-mainnet']]: {
-    poolAddressesProvider: '0xa97684ead0e402dc232d5a977953df7ecbab3cdb',
-    uiPoolDataProvider: '0xbd83ddbe37fc91923d59c8c1e0bde0cccca332d5',
-    uiIncentiveDataProvider: '0x6f143fe2f7b02424ad3cad1593d6f36c0aab69d7',
-    incentivesController: '0x929ec64c34a17401f460460d4b9390518e5b473e',
-    pool: '0x794a61358d6845594f94dc1db02a252b5b4814ad',
+    poolAddressesProvider: AaveV3Optimism.POOL_ADDRESSES_PROVIDER,
+    uiPoolDataProvider: '0x86b0521f92a554057e54B93098BA2A6Aaa2F4ACB', // todo: use AaveV3Optimism.UI_POOL_DATA_PROVIDER, when it is updated in the address book
+    uiIncentiveDataProvider: '0xc0179321f0825c3e0F59Fe7Ca4E40557b97797a3', // todo: use AaveV3Optimism.UI_INCENTIVE_DATA_PROVIDER when it is updated in the address book
+    incentivesController: AaveV3Optimism.DEFAULT_INCENTIVES_CONTROLLER,
+    pool: AaveV3Optimism.POOL,
   },
   [NetworkId['op-sepolia']]: {
-    poolAddressesProvider: '0x36616cf17557639614c1cddb356b1b83fc0b2132',
-    uiPoolDataProvider: '0x86e2938dae289763d4e09a7e42c5ccca62cf9809',
-    uiIncentiveDataProvider: '0xcfdada7dcd2e785cf706badbc2b8af5084d595e9',
-    incentivesController: '0xad4f91d26254b6b0c6346b390dda2991fde2f20d',
-    pool: '0xb50201558b00496a145fe76f7424749556e326d8',
+    poolAddressesProvider: AaveV3OptimismSepolia.POOL_ADDRESSES_PROVIDER,
+    uiPoolDataProvider: AaveV3OptimismSepolia.UI_POOL_DATA_PROVIDER,
+    uiIncentiveDataProvider: AaveV3OptimismSepolia.UI_INCENTIVE_DATA_PROVIDER,
+    incentivesController: AaveV3OptimismSepolia.DEFAULT_INCENTIVES_CONTROLLER,
+    pool: AaveV3OptimismSepolia.POOL,
   },
   [NetworkId['polygon-pos-mainnet']]: {
-    poolAddressesProvider: '0xa97684ead0e402dc232d5a977953df7ecbab3cdb',
-    uiPoolDataProvider: '0xc69728f11e9e6127733751c8410432913123acf1',
-    uiIncentiveDataProvider: '0x874313a46e4957d29faac43bf5eb2b144894f557',
-    incentivesController: '0x929ec64c34a17401f460460d4b9390518e5b473e',
-    pool: '0x794a61358d6845594f94dc1db02a252b5b4814ad',
+    poolAddressesProvider: AaveV3Polygon.POOL_ADDRESSES_PROVIDER,
+    uiPoolDataProvider: '0xE92cd6164CE7DC68e740765BC1f2a091B6CBc3e4', // todo: use AaveV3Polygon.UI_POOL_DATA_PROVIDER when it is updated in the address book
+    uiIncentiveDataProvider: '0x5c5228aC8BC1528482514aF3e27E692495148717', // todo: use AaveV3Polygon.UI_INCENTIVE_DATA_PROVIDER when it is updated in the address book
+    incentivesController: AaveV3Polygon.DEFAULT_INCENTIVES_CONTROLLER,
+    pool: AaveV3Polygon.POOL,
   },
   [NetworkId['polygon-pos-amoy']]: undefined,
   [NetworkId['base-mainnet']]: {
-    poolAddressesProvider: '0xe20fcbdbffc4dd138ce8b2e6fbb6cb49777ad64d',
-    uiPoolDataProvider: '0x174446a6741300cd2e7c1b1a636fee99c8f83502',
-    uiIncentiveDataProvider: '0xedd3b4737c1a0011626631a977b91cf3e944982d',
-    incentivesController: '0xf9cc4f0d883f1a1eb2c253bdb46c254ca51e1f44',
-    pool: '0xa238dd80c259a72e81d7e4664a9801593f98d1c5',
+    poolAddressesProvider: AaveV3Base.POOL_ADDRESSES_PROVIDER,
+    uiPoolDataProvider: '0xE92cd6164CE7DC68e740765BC1f2a091B6CBc3e4', // todo: use AaveV3Base.UI_POOL_DATA_PROVIDER when it is updated in the address book
+    uiIncentiveDataProvider: '0x5c5228aC8BC1528482514aF3e27E692495148717', // todo: use AaveV3Base.UI_INCENTIVE_DATA_PROVIDER when it is updated in the address book
+    incentivesController: AaveV3Base.DEFAULT_INCENTIVES_CONTROLLER,
+    pool: AaveV3Base.POOL,
   },
-  [NetworkId['base-sepolia']]: {
-    poolAddressesProvider: '0xd449fed49d9c443688d6816fe6872f21402e41de',
-    uiPoolDataProvider: '0x884702e4b1d0a2900369e83d5765d537f469cac9',
-    uiIncentiveDataProvider: '0x52cb5cdf732889be3fd5d5e3a5d589446e060c0d',
-    incentivesController: '0x659fbb419151b8e752c4589dffca3403865b7232',
-    pool: '0x07ea79f68b2b3df564d0a34f8e19d9b1e339814b',
-  },
+  [NetworkId['base-sepolia']]: undefined, // does not have UI_POOL_DATA_PROVIDER
 }
 
 enum AaveMarketName {

--- a/src/apps/aave/positions.ts
+++ b/src/apps/aave/positions.ts
@@ -186,9 +186,6 @@ const hook: PositionsHook = {
         const variableBorrowApy = getApyFromRayApr(
           reserveData.variableBorrowRate,
         )
-        const stableBorrowApy = getApyFromRayApr(
-          userReserveData?.[i].stableBorrowRate || reserveData.stableBorrowRate,
-        )
 
         // Include a token if the user has a balance
         // or if no user data is available (when querying all positions)
@@ -196,8 +193,6 @@ const hook: PositionsHook = {
           !userReserveData || userReserveData[i].scaledATokenBalance > 0n
         const useVariableDebt =
           !userReserveData || userReserveData[i].scaledVariableDebt > 0n
-        const useStableDebt =
-          !userReserveData || userReserveData[i].principalStableDebt > 0n
 
         return [
           // AToken
@@ -288,24 +283,6 @@ const hook: PositionsHook = {
               },
               // TODO: update runtime so we can specify a negative balance for debt
               // instead of using a negative pricePerShare
-              pricePerShare: [new BigNumber(-1) as DecimalNumber],
-            } satisfies AppTokenPositionDefinition),
-          // Stable debt token
-          useStableDebt &&
-            ({
-              type: 'app-token-definition',
-              networkId,
-              address: reserveData.stableDebtTokenAddress.toLowerCase(),
-              tokens: [{ address: reserveData.underlyingAsset, networkId }],
-              displayProps: {
-                title: `${reserveData.symbol} debt`,
-                description: `Borrowed stable (APY: ${stableBorrowApy.toFixed(
-                  2,
-                )}%)`,
-                imageUrl: AAVE_LOGO,
-                manageUrl,
-              },
-              // TODO: similar as comment above for variable debt
               pricePerShare: [new BigNumber(-1) as DecimalNumber],
             } satisfies AppTokenPositionDefinition),
         ].filter((x) => !!x)

--- a/yarn.lock
+++ b/yarn.lock
@@ -369,6 +369,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@bgd-labs/aave-address-book@^3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@bgd-labs/aave-address-book/-/aave-address-book-3.7.0.tgz#5863754f16a986c49e712860f8919b421c0af6f7"
+  integrity sha512-uujysWEGz5cOV7s8e6jD0MOuRff7ujLFqtYtw8w1U5JnkAA5eCX/AWmeIx1xdBcd2hBzK52PlWbCeYXA4S8GeQ==
+
 "@confio/ics23@^0.6.8":
   version "0.6.8"
   resolved "https://registry.yarnpkg.com/@confio/ics23/-/ics23-0.6.8.tgz#2a6b4f1f2b7b20a35d9a0745bb5a446e72930b3d"


### PR DESCRIPTION
Brings back #610, but removes stable token debt, seems to be all 0x000000... addresses. This should fix the issue related to Aave pool not showing up