### PR TITLE
feat(earn): Add claimType and withdrawalIncludesClaim to dataProps

### DIFF
--- a/src/apps/aave/positions.ts
+++ b/src/apps/aave/positions.ts
@@ -4,6 +4,7 @@ import {
   UnknownAppTokenError,
   TokenDefinition,
   ContractPositionDefinition,
+  ClaimType,
 } from '../../types/positions'
 import { Address } from 'viem'
 import {
@@ -229,6 +230,7 @@ const hook: PositionsHook = {
               },
               dataProps: {
                 manageUrl,
+                claimType: ClaimType.Rewards,
                 termsUrl: AAVE_TERMS_URL,
                 cantSeparateCompoundedInterest: true,
                 contractCreatedAt:

--- a/src/apps/allbridge/positions.ts
+++ b/src/apps/allbridge/positions.ts
@@ -4,6 +4,7 @@ import {
   UnknownAppTokenError,
   TokenDefinition,
   ContractPositionDefinition,
+  ClaimType,
 } from '../../types/positions'
 import { Address } from 'viem'
 import {
@@ -162,6 +163,8 @@ const hook: PositionsHook = {
             },
             dataProps: {
               manageUrl,
+              claimType: ClaimType.Earnings,
+              withdrawalIncludesClaim: true,
               termsUrl: ALLBRIDGE_TERMS_URL,
               contractCreatedAt:
                 ALLBRIGE_CONTRACT_CREATED_AT[

--- a/src/apps/beefy/positions.ts
+++ b/src/apps/beefy/positions.ts
@@ -6,6 +6,7 @@ import { NetworkId } from '../../types/networkId'
 import { toDecimalNumber, toSerializedDecimalNumber } from '../../types/numbers'
 import {
   AppTokenPositionDefinition,
+  ClaimType,
   ContractPositionDefinition,
   PositionsHook,
   TokenDefinition,
@@ -130,6 +131,7 @@ const beefyAppTokenDefinition = ({
       tvl: tvl ? toSerializedDecimalNumber(tvl) : undefined,
       manageUrl: `${BEEFY_VAULT_BASE_URL}${vault.id}`,
       contractCreatedAt: new Date(vault.createdAt * 1000).toISOString(),
+      claimType: ClaimType.Rewards,
     },
     availableShortcutIds: ['deposit', 'withdraw', 'swap-deposit'],
     shortcutTriggerArgs: ({ tokensByTokenId }) => {

--- a/src/types/positions.ts
+++ b/src/types/positions.ts
@@ -82,6 +82,11 @@ export interface EarningItem {
   includedInPoolBalance?: boolean
 }
 
+export enum ClaimType {
+  Earnings = 'earnings',
+  Rewards = 'rewards',
+}
+
 export interface EarnDataProps {
   contractCreatedAt?: string // ISO string
   manageUrl?: string
@@ -93,6 +98,8 @@ export interface EarnDataProps {
   depositTokenId: string
   withdrawTokenId: string
   rewardsPositionIds?: string[]
+  claimType?: ClaimType
+  withdrawalIncludesClaim?: boolean
   // We'll add more fields here as needed
 }
 


### PR DESCRIPTION
`claimType` needed to determine whether to show "Claim Earnings" or "Claim Rewards". `withdrawalIncludesClaim` needed to decide copy for pools that force claim when withdrawing (Allbridge).