### PR TITLE
test(beefy): Add unit tests for getDailyYieldRatePercentage

### DIFF
--- a/src/apps/beefy/positions.test.ts
+++ b/src/apps/beefy/positions.test.ts
@@ -1,0 +1,47 @@
+import { BaseBeefyVault } from './api'
+import { getDailyYieldRatePercentage } from './positions'
+
+const apyBreakdownWithCorrectComponents = {
+  vaultApr: 0.1,
+  clmApr: 0.2,
+  tradingApr: 0.3,
+}
+
+const apyBreakdownWithIncorrectComponents = {
+  unsupportedComponent: 0.1,
+  totalApy: 0.5,
+}
+
+const apyBreakdownWithRewardPoolApr = {
+  ...apyBreakdownWithCorrectComponents,
+  rewardPoolApr: 0.4,
+}
+
+const vault: BaseBeefyVault = {
+  type: 'gov',
+  subType: 'cowcentrated',
+} as BaseBeefyVault
+
+describe('getDailyYieldRatePercentage', () => {
+  it('should return the correct daily yield rate percentage when there are components', () => {
+    const dailyYieldRatePercentage = getDailyYieldRatePercentage(
+      apyBreakdownWithCorrectComponents,
+      vault,
+    )
+    expect(dailyYieldRatePercentage).toBeCloseTo(0.164)
+  })
+  it('should return the correct daily yield rate percentage when there are no correct components', () => {
+    const dailyYieldRatePercentage = getDailyYieldRatePercentage(
+      apyBreakdownWithIncorrectComponents,
+      vault,
+    )
+    expect(dailyYieldRatePercentage).toBeCloseTo(0.111)
+  })
+  it('should not include rewardPoolApr in the daily yield rate percentage for gov cowcentrated vault', () => {
+    const dailyYieldRatePercentage = getDailyYieldRatePercentage(
+      apyBreakdownWithRewardPoolApr,
+      vault,
+    )
+    expect(dailyYieldRatePercentage).toBeCloseTo(0.164)
+  })
+})

--- a/src/apps/beefy/positions.test.ts
+++ b/src/apps/beefy/positions.test.ts
@@ -12,11 +12,6 @@ const apyBreakdownWithIncorrectComponents = {
   totalApy: 0.5,
 }
 
-const apyBreakdownWithRewardPoolApr = {
-  ...apyBreakdownWithCorrectComponents,
-  rewardPoolApr: 0.4,
-}
-
 const vault: BaseBeefyVault = {
   type: 'gov',
   subType: 'cowcentrated',
@@ -39,7 +34,21 @@ describe('getDailyYieldRatePercentage', () => {
   })
   it('should not include rewardPoolApr in the daily yield rate percentage for gov cowcentrated vault', () => {
     const dailyYieldRatePercentage = getDailyYieldRatePercentage(
-      apyBreakdownWithRewardPoolApr,
+      { ...apyBreakdownWithCorrectComponents, rewardPoolApr: 0.4 },
+      vault,
+    )
+    expect(dailyYieldRatePercentage).toBeCloseTo(0.164)
+  })
+  it('should return 0 if totalApy is undefined and no components', () => {
+    const dailyYieldRatePercentage = getDailyYieldRatePercentage({}, vault)
+    expect(dailyYieldRatePercentage).toBe(0)
+  })
+  it('should ignore components that are NaN', () => {
+    const dailyYieldRatePercentage = getDailyYieldRatePercentage(
+      {
+        ...apyBreakdownWithCorrectComponents,
+        merklApr: NaN,
+      },
       vault,
     )
     expect(dailyYieldRatePercentage).toBeCloseTo(0.164)

--- a/src/apps/beefy/positions.ts
+++ b/src/apps/beefy/positions.ts
@@ -167,7 +167,7 @@ const beefyAppTokenDefinition = ({
 }
 
 // Based on https://github.com/beefyfinance/beefy-v2/blob/4413697f3d3cb5e090d8bb6958b621a673f0d739/src/features/data/actions/apy.ts#L46
-function getDailyYieldRatePercentage(
+export function getDailyYieldRatePercentage(
   apyBreakdown: BeefyApyBreakdown[string],
   vault: BaseBeefyVault,
 ) {


### PR DESCRIPTION
Unit tests added to cover:
- when there are breakdown components
- when there are no breakdown components
- when it needs to remove `rewardPoolApr`