### PR TITLE
fix(gooddollar): tell existing users to re-verify after their verification expires

### DIFF
--- a/src/apps/gooddollar/positions.e2e.ts
+++ b/src/apps/gooddollar/positions.e2e.ts
@@ -3,9 +3,7 @@ import { NetworkId } from '../../types/networkId'
 import { t } from '../../../test/i18next'
 
 describe('getPositionDefinitions', () => {
-  // temporarily disabling while we fix the position
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('should get the address definitions successfully', async () => {
+  it('should get the address definitions successfully', async () => {
     const positions = await hook.getPositionDefinitions({
       networkId: NetworkId['celo-mainnet'],
       address: '0xb847ea9e017779bf63947ad72cd6bf06407cd2e1',
@@ -13,5 +11,14 @@ describe('getPositionDefinitions', () => {
     })
     // Simple check to make sure we got some definitions
     expect(positions.length).toBeGreaterThan(0)
+  })
+
+  it('should return no positions if the user is new', async () => {
+    const positions = await hook.getPositionDefinitions({
+      networkId: NetworkId['celo-mainnet'],
+      address: '0x0000000000000000000000000000000000007e57',
+      t,
+    })
+    expect(positions.length).toBe(0)
   })
 })

--- a/src/apps/gooddollar/positions.ts
+++ b/src/apps/gooddollar/positions.ts
@@ -49,12 +49,17 @@ const hook: PositionsHook = {
       abi: identityAbi,
     } as const
 
-    const [isVerified, currentDay, periodStart, claimAmount] =
+    const [isVerified, isNotNewUser, currentDay, periodStart, claimAmount] =
       await client.multicall({
         contracts: [
           {
             ...identityContract,
             functionName: 'isWhitelisted',
+            args: [address as Address],
+          },
+          {
+            ...ubiContract,
+            functionName: 'isNotNewUser',
             args: [address as Address],
           },
           {
@@ -74,7 +79,10 @@ const hook: PositionsHook = {
         allowFailure: false,
       })
 
-    if (!isVerified) {
+    // If the user is not verified or is new, they don't have a position
+    // Note: existing users need to re-verify after some time
+    // in that case, they will have a position but we will tell them to re-verify
+    if (!isVerified && !isNotNewUser) {
       return []
     }
 
@@ -96,7 +104,7 @@ const hook: PositionsHook = {
       displayProps: {
         title: 'Daily UBI',
         description: !isVerified
-          ? 'Verify on the dapp to claim'
+          ? 'Re-verify on the dapp to claim'
           : claimAmount > 0n
           ? 'Claim now'
           : // Claim in X hours
@@ -108,7 +116,7 @@ const hook: PositionsHook = {
             )}`,
         imageUrl:
           'https://raw.githubusercontent.com/valora-inc/dapp-list/main/assets/gooddollar.png',
-        manageUrl: 'https://gooddapp.org/#/stakes',
+        manageUrl: 'https://gooddapp.org/#/claim',
       },
       balances: [toDecimalNumber(claimAmount, G$_DECIMALS)],
     }


### PR DESCRIPTION
Follow up to https://github.com/valora-inc/hooks/pull/632

The verification status for the test account we were using expired.

We now keep showing the claimable position for existing users that were previously verified and they can do so on the dapp.