### PR TITLE
feat: adjust estimated gas for deposit shortcuts

### DIFF
--- a/src/apps/aave/shortcuts.ts
+++ b/src/apps/aave/shortcuts.ts
@@ -28,9 +28,8 @@ import { ChainType, SquidCallType } from '@0xsquid/squid-types'
 import { prepareSwapTransactions } from '../../utils/prepareSwapTransactions'
 
 // Hardcoded fallback if simulation isn't enabled
-const GAS = 1_000_000n
-// Padding we add to simulation gas to ensure we specify enough
-const SIMULATED_DEPOSIT_GAS_PADDING = 250_000n
+const DEFAULT_DEPOSIT_GAS = 1_000_000n
+const DEFAULT_APPROVE_GAS = 200_000n
 
 const hook: ShortcutsHook = {
   async getShortcutDefinitions(networkId: NetworkId, _address?: string) {
@@ -115,13 +114,12 @@ const hook: ShortcutsHook = {
             const supplySimulatedTx =
               simulatedTransactions[simulatedTransactions.length - 1]
 
-            supplyTx.gas =
-              BigInt(supplySimulatedTx.gasNeeded) +
-              SIMULATED_DEPOSIT_GAS_PADDING
+            // 15% buffer on the estimation from the simulation
+            supplyTx.gas = (BigInt(supplySimulatedTx.gasNeeded) * 115n) / 100n
             supplyTx.estimatedGasUse = BigInt(supplySimulatedTx.gasUsed)
           } catch (error) {
-            supplyTx.gas = GAS
-            supplyTx.estimatedGasUse = GAS / 3n
+            supplyTx.gas = DEFAULT_DEPOSIT_GAS
+            supplyTx.estimatedGasUse = DEFAULT_DEPOSIT_GAS / 3n
           }
 
           return { transactions }
@@ -277,7 +275,7 @@ const hook: ShortcutsHook = {
                   },
                   // no native token transfer. this is optional per types, but squid request fails without it
                   value: '0',
-                  estimatedGas: GAS.toString(),
+                  estimatedGas: DEFAULT_APPROVE_GAS.toString(),
                 },
                 {
                   chainType: ChainType.EVM,
@@ -290,7 +288,7 @@ const hook: ShortcutsHook = {
                   },
                   // no native token transfer. this is optional per types, but squid request fails without it
                   value: '0',
-                  estimatedGas: GAS.toString(),
+                  estimatedGas: DEFAULT_DEPOSIT_GAS.toString(),
                 },
               ],
               description: 'Deposit into aave pool',

--- a/src/apps/beefy/shortcuts.ts
+++ b/src/apps/beefy/shortcuts.ts
@@ -22,8 +22,7 @@ import { prepareSwapTransactions } from '../../utils/prepareSwapTransactions'
 
 // Hardcoded fallback if simulation isn't enabled
 const DEFAULT_DEPOSIT_GAS = 750_000n
-// Padding we add to simulation gas to ensure we specify enough
-const SIMULATED_DEPOSIT_GAS_PADDING = 200_000n
+const DEFAULT_APPROVE_GAS = 200_000n
 
 const hook: ShortcutsHook = {
   async getShortcutDefinitions(networkId: NetworkId) {
@@ -103,9 +102,8 @@ const hook: ShortcutsHook = {
             const supplySimulatedTx =
               simulatedTransactions[simulatedTransactions.length - 1]
 
-            depositTx.gas =
-              BigInt(supplySimulatedTx.gasNeeded) +
-              SIMULATED_DEPOSIT_GAS_PADDING
+            // 15% buffer on the estimation from the simulation
+            depositTx.gas = (BigInt(supplySimulatedTx.gasNeeded) * 115n) / 100n
             depositTx.estimatedGasUse = BigInt(supplySimulatedTx.gasUsed)
           } catch (error) {
             if (!(error instanceof UnsupportedSimulateRequest)) {
@@ -215,7 +213,6 @@ const hook: ShortcutsHook = {
             swapFromToken,
             swapToTokenAddress: tokenAddress,
             walletAddress,
-            simulatedGasPadding: [0n, SIMULATED_DEPOSIT_GAS_PADDING],
             enableAppFee,
             // based off of https://docs.squidrouter.com/building-with-squid-v2/key-concepts/hooks/build-a-posthook
             postHook: {
@@ -232,7 +229,7 @@ const hook: ShortcutsHook = {
                   },
                   // no native token transfer. this is optional per types, but squid request fails without it
                   value: '0',
-                  estimatedGas: DEFAULT_DEPOSIT_GAS.toString(),
+                  estimatedGas: DEFAULT_APPROVE_GAS.toString(),
                 },
                 {
                   chainType: ChainType.EVM,

--- a/src/utils/prepareSwapTransactions.test.ts
+++ b/src/utils/prepareSwapTransactions.test.ts
@@ -85,7 +85,6 @@ describe('prepareSwapTransactions', () => {
       swapFromToken: mockNativeSwapFromToken,
       swapToTokenAddress: '0x724dc807b04555b71ed48a6896b6f41593b8c637',
       postHook: mockPostHook,
-      simulatedGasPadding: [1n, 100n],
     })
 
     expect(transactions).toHaveLength(1)
@@ -95,7 +94,7 @@ describe('prepareSwapTransactions', () => {
       to: '0x12345678',
       data: '0xswapdata',
       value: 111n,
-      gas: 12345n,
+      gas: 14042n,
       estimatedGasUse: 12211n,
     })
     expect(dataProps).toEqual({ swapTransaction })
@@ -152,7 +151,7 @@ describe('prepareSwapTransactions', () => {
       to: '0x12345678',
       data: '0xswapdata',
       value: 111n,
-      gas: 12345n,
+      gas: 14042n,
       estimatedGasUse: 12211n,
     })
     expect(dataProps).toEqual({ swapTransaction })
@@ -206,48 +205,9 @@ describe('prepareSwapTransactions', () => {
       to: '0x12345678',
       data: '0xswapdata',
       value: 111n,
-      gas: 12345n,
+      gas: 14042n,
       estimatedGasUse: 12211n,
     })
-  })
-
-  it('uses default gas for postHook', async () => {
-    const { transactions } = await prepareSwapTransactions({
-      networkId: NetworkId['arbitrum-one'],
-      walletAddress: '0x2b8441ef13333ffa955c9ea5ab5b3692da95260d',
-      swapFromToken: mockNativeSwapFromToken,
-      swapToTokenAddress: '0x724dc807b04555b71ed48a6896b6f41593b8c637',
-      postHook: mockPostHook,
-      simulatedGasPadding: [1n, 100n],
-    })
-
-    expect(transactions).toHaveLength(1)
-    expect(transactions[0]).toEqual({
-      networkId: NetworkId['arbitrum-one'],
-      from: mockWalletAddress,
-      to: '0x12345678',
-      data: '0xswapdata',
-      value: 111n,
-      gas: 12345n,
-      estimatedGasUse: 12211n,
-    })
-    expect(got.post).toHaveBeenCalledTimes(1)
-    expect(got.post).toHaveBeenCalledWith(
-      'https://api.mainnet.valora.xyz/getSwapQuote',
-      {
-        json: {
-          buyToken: '0x724dc807b04555b71ed48a6896b6f41593b8c637',
-          buyIsNative: false,
-          buyNetworkId: NetworkId['arbitrum-one'],
-          sellIsNative: true,
-          sellNetworkId: NetworkId['arbitrum-one'],
-          sellAmount: (1e18).toString(),
-          slippagePercentage: '1',
-          postHook: mockPostHook,
-          userAddress: mockWalletAddress,
-        },
-      },
-    )
   })
 
   it('throws if getting swap quote fails', async () => {

--- a/src/utils/prepareSwapTransactions.test.ts
+++ b/src/utils/prepareSwapTransactions.test.ts
@@ -110,19 +110,7 @@ describe('prepareSwapTransactions', () => {
           sellNetworkId: NetworkId['arbitrum-one'],
           sellAmount: (1e18).toString(),
           slippagePercentage: '1',
-          postHook: {
-            ...mockPostHook,
-            calls: [
-              {
-                ...mockPostHook.calls[0],
-                estimatedGas: '1000',
-              },
-              {
-                ...mockPostHook.calls[1],
-                estimatedGas: '2000',
-              },
-            ],
-          },
+          postHook: mockPostHook,
           userAddress: mockWalletAddress,
         },
       },
@@ -168,19 +156,7 @@ describe('prepareSwapTransactions', () => {
           sellNetworkId: NetworkId['arbitrum-one'],
           sellAmount: (1e6).toString(),
           slippagePercentage: '1',
-          postHook: {
-            ...mockPostHook,
-            calls: [
-              {
-                ...mockPostHook.calls[0],
-                estimatedGas: '1000',
-              },
-              {
-                ...mockPostHook.calls[1],
-                estimatedGas: '2000',
-              },
-            ],
-          },
+          postHook: mockPostHook,
           userAddress: mockWalletAddress,
         },
       },

--- a/src/utils/prepareSwapTransactions.ts
+++ b/src/utils/prepareSwapTransactions.ts
@@ -44,7 +44,6 @@ export async function prepareSwapTransactions({
   swapToTokenAddress: Address
   networkId: NetworkId
   walletAddress: Address
-  simulatedGasPadding?: bigint[]
   enableAppFee?: boolean
 }): Promise<TriggerOutputShape<'swap-deposit'>> {
   const amountToSwap = parseUnits(swapFromToken.amount, swapFromToken.decimals)
@@ -137,7 +136,11 @@ export async function prepareSwapTransactions({
     to,
     data,
     value: BigInt(value),
-    gas: BigInt(gas),
+    // estimatedGasUse is from the simulation, gas is from the swap provider
+    // add 15% padding to the simulation
+    gas: estimatedGasUse
+      ? (BigInt(estimatedGasUse) * 115n) / 100n
+      : BigInt(gas),
     estimatedGasUse: estimatedGasUse ? BigInt(estimatedGasUse) : undefined,
   }
 

--- a/src/utils/prepareSwapTransactions.ts
+++ b/src/utils/prepareSwapTransactions.ts
@@ -137,7 +137,8 @@ export async function prepareSwapTransactions({
     data,
     value: BigInt(value),
     // estimatedGasUse is from the simulation, gas is from the swap provider
-    // add 15% padding to the simulation
+    // add 15% padding to the simulation if it's available, otherwise fallback
+    // to the swap provider's gas
     gas: estimatedGasUse
       ? (BigInt(estimatedGasUse) * 115n) / 100n
       : BigInt(gas),


### PR DESCRIPTION
For ACT-1394. 
Changes include:
- Adjusting postHook default estimatedGas for swap-deposit txs
- Using gas from simulation instead of swap provider for swap-deposit txs 
  - Swaps use swap provider gas and ignores simulation results here for gas limit of the tx https://github.com/valora-inc/valora-rest-api/blob/ddf710202b63bfd9f02dc104b6aa812d64809c47/src/swaps/simulateSwap.ts#L156, this can be adjusted in swaps but for now trying this out in swap deposit
- Adding 15% buffer to simulation results to be extra cautious
  - Replaces the static 250k padding for deposits, but that was actually needed because of an issue with negative gas refunds (fixed in https://github.com/valora-inc/valora-rest-api/pull/1201) 

This can be monitored and adjusted based on these metrics: https://mixpanel.com/project/2786968/view/3321744/app/insights#vAou6TfFHjbW